### PR TITLE
Fixing username detection in win os (POSIX)

### DIFF
--- a/src/lib/ConfigurationParser.php
+++ b/src/lib/ConfigurationParser.php
@@ -61,6 +61,12 @@ trait ConfigurationParser {
 	 */
 	protected function getSystemUser()
 	{
+	        $system = strtolower(php_uname());
+
+	        if (str_contains($system, 'win')) {
+			return getenv('USERNAME');
+	        }
+
 		return posix_getpwuid(posix_geteuid())['name'];
 	}
 


### PR DESCRIPTION
Under win os while running:

`bin/envoy run foo`

Throws up an error, as POSIX extension is not available under windows:

`Fatal error: Call to undefined function Laravel\Envoy\posix_getpwuid()`
