### PR TITLE
Added error callbacks

### DIFF
--- a/src/lib/Compiler.php
+++ b/src/lib/Compiler.php
@@ -31,6 +31,8 @@ class Compiler {
 		'MacroStop',
 		'TaskStart',
 		'TaskStop',
+		'Error',
+		'ErrorStop',
 		'After',
 		'AfterStop',
 		'Hipchat',
@@ -296,6 +298,30 @@ class Compiler {
 		$pattern = $this->createPlainMatcher('endtask');
 
 		return preg_replace($pattern, '$1<?php $__container->endTask(); ?>$2', $value);
+	}
+
+	/**
+	 * Compile Envoy error statements into valid PHP.
+	 *
+	 * @param  string  $value
+	 * @return string
+	 */
+	protected function compileError($value)
+	{
+		$pattern = $this->createPlainMatcher('error');
+
+		return preg_replace($pattern, '$1<?php $__container->error(function($task) {$2', $value);
+	}
+
+	/**
+	 * Compile Envoy error stop statements into valid PHP.
+	 *
+	 * @param  string  $value
+	 * @return string
+	 */
+	protected function compileErrorStop($value)
+	{
+		return preg_replace($this->createPlainMatcher('enderror'), '$1}); ?>$2', $value);
 	}
 
 	/**

--- a/src/lib/Console/RunCommand.php
+++ b/src/lib/Console/RunCommand.php
@@ -72,6 +72,11 @@ class RunCommand extends \Symfony\Component\Console\Command\Command {
 	{
 		if ($this->runTaskOverSSH($container->getTask($task)) > 0)
 		{
+			foreach ($container->getErrorCallbacks() as $callback)
+			{
+				call_user_func($callback, $task);
+			}
+
 			return;
 		}
 

--- a/src/lib/TaskContainer.php
+++ b/src/lib/TaskContainer.php
@@ -26,6 +26,13 @@ class TaskContainer {
 	protected $tasks = [];
 
 	/**
+	 * All of the "error" callbacks.
+	 *
+	 * @var array
+	 */
+	protected $error = [];
+
+	/**
 	 * All of the "after" callbacks.
 	 *
 	 * @var array
@@ -274,6 +281,27 @@ class TaskContainer {
 	public function endTask()
 	{
 		$this->tasks[array_pop($this->taskStack)] = trim(ob_get_clean());
+	}
+
+	/**
+	 * Register an error-task callback.
+	 *
+	 * @param  \Closure  $callback
+	 * @return void
+	 */
+	public function error(Closure $callback)
+	{
+		$this->error[] = $callback;
+	}
+
+	/**
+	 * Get all of the error-task callbacks.
+	 *
+	 * @return array
+	 */
+	public function getErrorCallbacks()
+	{
+		return $this->error;
 	}
 
 	/**


### PR DESCRIPTION
Added `@error` which works just like `@after`.

This was needed so I could send a Hipchat message if a deploy had failed.
