### PR TITLE
allow for color override in hipchat

### DIFF
--- a/src/lib/Hipchat.php
+++ b/src/lib/Hipchat.php
@@ -10,6 +10,7 @@ class Hipchat {
 	public $room;
 	public $from;
 	public $message;
+	public $color;
 
 	/**
 	 * Create a new Hipchat instance.
@@ -18,14 +19,16 @@ class Hipchat {
 	 * @param  mixed  $room
 	 * @param  string  $from
 	 * @param  string  $message
+	 * @param  string  $color
 	 * @return void
 	 */
-	public function __construct($token, $room, $from, $message = null)
+	public function __construct($token, $room, $from, $message = null, $color = 'purple')
 	{
 		$this->room = $room;
 		$this->from = $from;
 		$this->token = $token;
 		$this->message = $message;
+		$this->color = $color;
 	}
 
 	/**
@@ -35,11 +38,12 @@ class Hipchat {
 	 * @param  mixed  $room
 	 * @param  string  $from
 	 * @param  string  $message
+	 * @param  string  $color
 	 * @return \Laravel\Envoy\Hipchat
 	 */
-	public static function make($token, $room, $from, $message = null)
+	public static function make($token, $room, $from, $message = null, $color = 'purple')
 	{
-		return new static($token, $room, $from, $message);
+		return new static($token, $room, $from, $message, $color);
 	}
 
 	/**
@@ -54,7 +58,7 @@ class Hipchat {
 		$payload = [
 			'auth_token' => $this->token, 'room_id' => $this->room,
 			'from' => $this->from, 'message' => $message,
-			'message_format' => 'text', 'notify' => 1, 'color' => 'purple',
+			'message_format' => 'text', 'notify' => 1, 'color' => $this->color,
 		];
 
 		Request::get('https://api.hipchat.com/v1/rooms/message?'.http_build_query($payload))->send();


### PR DESCRIPTION
We, along with a lot of other people, have specific color coded message types when we send messages to hipchat. This update simply allows us to control the color of the message being sent to conform with our coloring (default set to purple)
