### PR TITLE
Allow to use illuminate/support v5+ to avoid loading Laravel explicit helpers such as app() etc.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"classmap": ["src"]
 	},
 	"require": {
-		"illuminate/support": "~4.1",
+		"illuminate/support": "~4.1|~5.0",
 		"nategood/httpful": "~0.2",
 		"symfony/console": "~2.3",
 		"symfony/process": "~2.3"


### PR DESCRIPTION
Signed-off-by: crynobone crynobone@gmail.com
