### PR TITLE
Fix ssh command concat error

### DIFF
--- a/src/Console/SshCommand.php
+++ b/src/Console/SshCommand.php
@@ -34,7 +34,7 @@ class SshCommand extends \Symfony\Component\Console\Command\Command {
 	{
 		$host = $this->getServer($container = $this->loadTaskContainer());
 
-		passthru('ssh '.$this->getConfiguredServer($host) ?: $host);
+		passthru('ssh '.($this->getConfiguredServer($host) ?: $host));
 	}
 
 	/**


### PR DESCRIPTION
the precedence concatenation operator (`.`) is higher than the ternary operator (`?:`), so the ssh command concat expresion has a fault.

an example:

```php
php > $host = 'foo';
php > $cmd = 'ssh ' . $host ?: 'bar';
php > echo $cmd, PHP_EOL;
ssh foo
php > $host = '';
php > $cmd = 'ssh ' . $host ?: 'bar';
php > echo $cmd, PHP_EOL;
ssh
php >
```