### PR TITLE
Add meaningful error messages for undefined tasks/servers/macros

### DIFF
--- a/src/TaskContainer.php
+++ b/src/TaskContainer.php
@@ -152,6 +152,10 @@ class TaskContainer {
 	 */
 	public function getServer($server)
 	{
+		if (! array_key_exists($server, $this->servers)) {
+			throw new \Exception(sprintf('Server "%s" is not defined.'));
+		}
+	    
 		return array_get($this->servers, $server);
 	}
 
@@ -183,6 +187,10 @@ class TaskContainer {
 	 */
 	public function getMacro($macro)
 	{
+		if (! array_key_exists($macro, $this->macros)) {
+			throw new \Exception(sprintf('Macro "%s" is not defined.', $macro));
+		}
+		
 		return array_get($this->macros, $macro);
 	}
 
@@ -196,6 +204,10 @@ class TaskContainer {
 	{
 		$script = array_get($this->tasks, $task, '');
 
+		if ($script == '') {
+			throw new \Exception(sprintf('Task "%s" is not defined.', $task));
+		}
+		
 		$options = $this->getTaskOptions($task);
 
 		$parallel = array_get($options, 'parallel', false);
@@ -222,7 +234,11 @@ class TaskContainer {
 	 */
 	protected function getServers(array $options)
 	{
-		return array_map(function($name) { return $this->servers[$name]; }, (array) $options['on']);
+		if (! array_key_exists('on', $options)) {
+			$options['on'] = [];
+		}
+	    
+		return array_map(function($name) { return $this->getServer($name); }, (array) $options['on']);
 	}
 
 	/**


### PR DESCRIPTION
# Throw exception on undefined task instead of crashing with PHP notice

Currently, when attempting to run a task or use a server that is not defined, envoy just fails with a PHP notice :

```
thibaud@thibaud-zbox [ ~/wks/project ] $ envoy run deploy
PHP Notice:  Undefined index: on in /home/thibaud/.composer/vendor/laravel/envoy/src/TaskContainer.php on line 225
PHP Stack trace:
PHP   1. {main}() /home/thibaud/.composer/vendor/laravel/envoy/envoy:0
PHP   2. Symfony\Component\Console\Application->run() /home/thibaud/.composer/vendor/laravel/envoy/envoy:11
PHP   3. Symfony\Component\Console\Application->doRun() /home/thibaud/.composer/vendor/symfony/console/Symfony/Component/Console/Application.php:126
PHP   4. Symfony\Component\Console\Application->doRunCommand() /home/thibaud/.composer/vendor/symfony/console/Symfony/Component/Console/Application.php:195
PHP   5. Symfony\Component\Console\Command\Command->run() /home/thibaud/.composer/vendor/symfony/console/Symfony/Component/Console/Application.php:874
PHP   6. Laravel\Envoy\Console\RunCommand->execute() /home/thibaud/.composer/vendor/symfony/console/Symfony/Component/Console/Command/Command.php:253
PHP   7. Laravel\Envoy\Console\RunCommand->fire() /home/thibaud/.composer/vendor/laravel/envoy/src/Console/Command.php:21
PHP   8. Laravel\Envoy\Console\RunCommand->runTask() /home/thibaud/.composer/vendor/laravel/envoy/src/Console/RunCommand.php:44
PHP   9. Laravel\Envoy\TaskContainer->getTask() /home/thibaud/.composer/vendor/laravel/envoy/src/Console/RunCommand.php:75
PHP  10. Laravel\Envoy\TaskContainer->getServers() /home/thibaud/.composer/vendor/laravel/envoy/src/TaskContainer.php:203
PHP Notice:  Undefined index: as in /home/thibaud/.composer/vendor/laravel/envoy/src/TaskContainer.php on line 203
PHP Stack trace:
PHP   1. {main}() /home/thibaud/.composer/vendor/laravel/envoy/envoy:0
PHP   2. Symfony\Component\Console\Application->run() /home/thibaud/.composer/vendor/laravel/envoy/envoy:11
PHP   3. Symfony\Component\Console\Application->doRun() /home/thibaud/.composer/vendor/symfony/console/Symfony/Component/Console/Application.php:126
PHP   4. Symfony\Component\Console\Application->doRunCommand() /home/thibaud/.composer/vendor/symfony/console/Symfony/Component/Console/Application.php:195
PHP   5. Symfony\Component\Console\Command\Command->run() /home/thibaud/.composer/vendor/symfony/console/Symfony/Component/Console/Application.php:874
PHP   6. Laravel\Envoy\Console\RunCommand->execute() /home/thibaud/.composer/vendor/symfony/console/Symfony/Component/Console/Command/Command.php:253
PHP   7. Laravel\Envoy\Console\RunCommand->fire() /home/thibaud/.composer/vendor/laravel/envoy/src/Console/Command.php:21
PHP   8. Laravel\Envoy\Console\RunCommand->runTask() /home/thibaud/.composer/vendor/laravel/envoy/src/Console/RunCommand.php:44
PHP   9. Laravel\Envoy\TaskContainer->getTask() /home/thibaud/.composer/vendor/laravel/envoy/src/Console/RunCommand.php:75
```

This P/R fixes that by throwing exceptions that provide a meaningful error message on the command line, to avoid having to decrypt the raised notices :

```
thibaud@thibaud-zbox [ ~/wks/project ] $ envoy run deploy


                                 
  [Exception]                    
  Task "deploy" is not defined.  
                                 


run [--pretend] task
```

The error messages are:

- Task "..." is not defined.
- Macro "..." is not defined.
- Server "..." is not defined.