### PR TITLE
Updated the Slack command fit the new Slack WebHook Integration

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -154,19 +154,20 @@ To run a task across multiple servers in parallel, use the `parallel` option on 
 @endtask
 
 @after
-	@slack('team', 'token', 'channel')
+	@slack('hook', 'channel')
 @endafter
 ```
 
 You may retrieve your token by creating an **Incoming WebHooks** integration on Slack's website.
 
-The team argument is your Slack subdomain (fooapp.slack.com = `fooapp`).
+The hook argument is the entire webhook URL provided by the Incoming Webhooks Slack Integration:
+
+- `https://hooks.slack.com/services/ZZZZZZZZZ/YYYYYYYYY/XXXXXXXXXXXXXXX`
 
 You may provide one of the following for the channel argument:
 
 - For a regular channel: `#channel`
 - For a specific user: `@user`
-- For a private group: `group`
 - If no argument is provided Envoy will use the default channel configured on the Slack website.
 
 > **Note:** Slack notifications will only be sent if all tasks complete successfully.

--- a/src/Slack.php
+++ b/src/Slack.php
@@ -6,24 +6,21 @@ class Slack {
 
 	use ConfigurationParser;
 
-	public $team;
-	public $token;
+	public $hook;
 	public $channel;
 	public $message;
 
 	/**
 	 * Create a new Slack instance.
 	 *
-	 * @param  string  $team
-	 * @param  string  $token
+	 * @param  string  $hook
 	 * @param  mixed  $channel
 	 * @param  string  $message
 	 * @return void
 	 */
-	public function __construct($team, $token, $channel = '', $message = null)
+	public function __construct($hook, $channel = '', $message = null)
 	{
-		$this->team = $team;
-		$this->token = $token;
+		$this->hook = $hook;
 		$this->channel = $channel;
 		$this->message = $message;
 	}
@@ -31,15 +28,14 @@ class Slack {
 	/**
 	 * Create a new Slack message instance.
 	 *
-	 * @param  string  $team
-	 * @param  string  $token
+	 * @param  string  $hook
 	 * @param  mixed   $channel
 	 * @param  string  $message
 	 * @return \Laravel\Envoy\Slack
 	 */
-	public static function make($team, $token, $channel = '', $message = null)
+	public static function make($hook, $channel = '', $message = null)
 	{
-		return new static($team, $token, $channel, $message);
+		return new static($hook, $channel, $message);
 	}
 
 	/**
@@ -53,7 +49,7 @@ class Slack {
 
 		$payload = ['text' => $message, 'channel' => $this->channel];
 
-        Request::post("https://{$this->team}.slack.com/services/hooks/incoming-webhook?token={$this->token}")->sendsJson()->body($payload)->send();
+        Request::post("{$this->hook}")->sendsJson()->body($payload)->send();
 	}
 
 	/**


### PR DESCRIPTION
The Slack WebHook has changed since the newest Envoy was released. It now takes the format of like this:

- `https://hooks.slack.com/services/ZZZZZZZZZ/YYYYYYYYY/XXXXXXXXXXXXXXX`

However the payload is the same. I simply removed the now defunct `team` argument and added the `hook` instead. `Hook` implies the entire url, I did it this way because that's how Slack presents it to you in the integrations page.

Also I updated the relevant documentation.