### PR TITLE
Remove exception if there's no macro

### DIFF
--- a/src/TaskContainer.php
+++ b/src/TaskContainer.php
@@ -187,10 +187,6 @@ class TaskContainer
      */
     public function getMacro($macro)
     {
-        if (! array_key_exists($macro, $this->macros)) {
-            throw new \Exception(sprintf('Macro "%s" is not defined.', $macro));
-        }
-
         return array_get($this->macros, $macro);
     }
 


### PR DESCRIPTION
This prevents envoy from throwing exception if no macro exists for a given task name, which blocks envoy from checking if a task actually exists.