### PR TITLE
Allow optional confirm message before running a task.

### DIFF
--- a/Envoy.blade.php
+++ b/Envoy.blade.php
@@ -4,6 +4,10 @@
 	ls -la
 @endtask
 
+@task('foo_confirm', ['on' => 'web', 'confirm' => 'Are you sure?'])
+    ls -la
+@endtask
+
 @after
 	@hipchat('token', 'room', 'Envoy')
 @endafter

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -57,6 +57,20 @@ trait Command
     }
 
     /**
+    * Asks the user for a confirmation.
+    * If y is pressed return true, if n is pressed return false
+    *
+    * @param string $question
+    * @return bool
+    */
+    public function askConfirmation($question)
+    {
+        $question = '<comment>'.$question.' [y/n]:</comment> ';
+
+        return  $this->getHelperSet()->get('dialog')->askConfirmation( $this->output, $question, false);
+    }
+
+    /**
      * Ask the user the given secret question.
      *
      * @param  string  $question

--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -79,6 +79,12 @@ class RunCommand extends \Symfony\Component\Console\Command\Command
      */
     protected function runTask($container, $task)
     {
+        $confirm = $container->getTask($task)->confirm;
+        if ($confirm && ! $this->askConfirmation($confirm))
+        {
+            return;
+        }
+        
         if (($exitCode = $this->runTaskOverSSH($container->getTask($task))) > 0) {
             foreach ($container->getErrorCallbacks() as $callback) {
                 call_user_func($callback, $task);

--- a/src/Task.php
+++ b/src/Task.php
@@ -31,6 +31,13 @@ class Task
      */
     public $parallel;
 
+    /*
+    * Asks a user for a confirmation.
+    *
+    * @var string
+    */
+    public $confirm;
+
     /**
      * Create a new Task instance.
      *
@@ -39,11 +46,12 @@ class Task
      * @param  string  $script
      * @return void
      */
-    public function __construct(array $hosts, $user, $script, $parallel = false)
+    public function __construct(array $hosts, $user, $script, $parallel = false, $confirm = null)
     {
         $this->user = $user;
         $this->hosts = $hosts;
         $this->script = $script;
         $this->parallel = $parallel;
+        $this->confirm = $confirm;
     }
 }

--- a/src/TaskContainer.php
+++ b/src/TaskContainer.php
@@ -208,7 +208,9 @@ class TaskContainer
 
         $parallel = array_get($options, 'parallel', false);
 
-        return new Task($this->getServers($options), $options['as'], $script, $parallel);
+        $confirm = array_get($options, 'confirm', null);
+
+        return new Task($this->getServers($options), $options['as'], $script, $parallel, $confirm);
     }
 
     /**


### PR DESCRIPTION
Added functionality to set a confirmation message in a task.
I find this pretty useful if you're running a destructive task (overwriting db, deploying to production etc).
Uses the symfony askConfirmation function from the dialog helper.