### PR TITLE
Add support for macro options.

### DIFF
--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -42,8 +42,10 @@ class RunCommand extends \Symfony\Component\Console\Command\Command
 
         $exitCode = 0;
 
-        foreach ($this->getTasks($container) as $task) {
-            $thisCode = $this->runTask($container, $task);
+        list( $tasks, $macro ) = $this->getTasks($container);
+
+        foreach ($tasks as $task) {
+            $thisCode = $this->runTask($container, $task, $macro);
 
             if (0 !== $thisCode) {
                 $exitCode = $thisCode;
@@ -61,10 +63,10 @@ class RunCommand extends \Symfony\Component\Console\Command\Command
      */
     protected function getTasks($container)
     {
-        $tasks = [$task = $this->argument('task')];
+        $tasks = [ [$task = $this->argument('task')], false ];
 
         if ($macro = $container->getMacro($task)) {
-            $tasks = $macro;
+            $tasks = [ $macro, $task ];
         }
 
         return $tasks;
@@ -74,12 +76,13 @@ class RunCommand extends \Symfony\Component\Console\Command\Command
      * Run the given task out of the container.
      *
      * @param  \Laravel\Envoy\TaskContainer  $container
-     * @param  string  $task
+     * @param  string       $task
+     * @param  bool|string  $macro
      * @return void
      */
-    protected function runTask($container, $task)
+    protected function runTask($container, $task, $macro)
     {
-        if (($exitCode = $this->runTaskOverSSH($container->getTask($task))) > 0) {
+        if (($exitCode = $this->runTaskOverSSH($container->getTask($task, $macro))) > 0) {
             foreach ($container->getErrorCallbacks() as $callback) {
                 call_user_func($callback, $task);
             }

--- a/src/TaskContainer.php
+++ b/src/TaskContainer.php
@@ -48,6 +48,13 @@ class TaskContainer
     protected $taskOptions = [];
 
     /**
+     * All of the options for each macro.
+     *
+     * @var array
+     */
+    protected $macroOptions = [];
+
+    /**
      * The stack of tasks being rendered.
      *
      * @var array
@@ -193,10 +200,11 @@ class TaskContainer
     /**
      * Get a Task instance by the given name.
      *
-     * @param  string  $task
+     * @param  string       $task
+     * @param  bool|string  $macro
      * @return string
      */
-    public function getTask($task)
+    public function getTask($task, $macro)
     {
         $script = array_get($this->tasks, $task, '');
 
@@ -204,7 +212,8 @@ class TaskContainer
             throw new \Exception(sprintf('Task "%s" is not defined.', $task));
         }
 
-        $options = $this->getTaskOptions($task);
+        // If this is a macro task, the macro options will take precedence over task options
+        $options = ( $macro !== false ) ? $this->getMacroOptions($macro) : $this->getTaskOptions($task);
 
         $parallel = array_get($options, 'parallel', false);
 
@@ -220,6 +229,17 @@ class TaskContainer
     public function getTaskOptions($task)
     {
         return array_get($this->taskOptions, $task, []);
+    }
+
+    /**
+     * Get the macro options for the given macro.
+     *
+     * @param  string  $macro
+     * @return array
+     */
+    public function getMacroOptions($macro)
+    {
+        return array_get($this->macroOptions, $macro, []);
     }
 
     /**
@@ -241,11 +261,14 @@ class TaskContainer
      * Begin defining a macro.
      *
      * @param  string  $macro
+     * @param  array   $options
      * @return void
      */
-    public function startMacro($macro)
+    public function startMacro($macro, array $options = array())
     {
         ob_start() && $this->macroStack[] = $macro;
+
+        $this->macroOptions[$macro] = $this->mergeDefaultOptions($options);
     }
 
     /**


### PR DESCRIPTION
Currently macro options are ignored, so if you have multiple servers, all tasks will run on all servers, even if you only need them to run on specific servers.

* Macro options take precedence over task options.
* If a task is called directly, its options will be used as per normal.

**Envoy.blade.php**
```php
@servers(['testing' => 'server1.example.com', 'staging' => 'server2.example.com', ])

@macro('test', [ 'on' => [ 'testing', 'staging', ], ])
    testing
@endmacro

@macro('stage', [ 'on' => 'staging', ])
    staging
@endmacro

@task('testing')
    echo 'testing';
@endtask

@task('staging')
    echo 'staging';
@endtask
```

**Task execution**
```
> ./envoy run test
[server1.example.com]: testing
[server2.example.com]: testing
> ./envoy run stage
[server2.example.com]: staging
> ./envoy run testing
[server1.example.com]: testing
[server2.example.com]: testing
> ./envoy run staging
[server1.example.com]: staging
[server2.example.com]: staging
```