### PR TITLE
Added way in which you can run Command Substitutions on remote server

### DIFF
--- a/src/RemoteProcessor.php
+++ b/src/RemoteProcessor.php
@@ -32,11 +32,8 @@ abstract class RemoteProcessor
         // script out to a file or anything. We will start the SSH process then pass
         // these lines of output back to the parent callback for display purposes.
         else {
-            $script = 'set -e'.PHP_EOL.$task->script;
             $process = new Process(
-                'ssh '.$target.' \'bash -s\' << EOF
-'.$script.'
-EOF'
+                'echo \'' . $task->script . '\' | ssh '.$target.' \'bash -se\''
             );
         }
 


### PR DESCRIPTION
I had a problem with running the command below with Envoy:
```
docker stop $(docker ps -a -q);
docker kill $(docker ps -a -q);
```

The problem was that ```docker ps -a -q``` will be executed on the host machine. Command substitution is as far as I know not possible in the way Envoy currently handles the ssh connection. By executing the script like: ```'echo \'' . $task->script . '\' | ssh '.$target.' \'bash -se\''``` it is possible to use Command Substitution because the script is rendered as string and then send to the remote machine.

Personaly I think it is more usefull to handle command substitution on the remote machine rather than on the host machine. Or was it completely intentional to handle this on the host machine?

PS the script keeps terminated when a non zero exit code is returned.