### PR TITLE
Allow to use several servers with a single name

### DIFF
--- a/src/TaskContainer.php
+++ b/src/TaskContainer.php
@@ -235,7 +235,8 @@ class TaskContainer
             $options['on'] = [];
         }
 
-        return array_map(function ($name) { return $this->getServer($name); }, (array) $options['on']);
+        $servers = array_map(function ($name) { return $this->getServer($name); }, (array) $options['on']);
+        return array_flatten($servers);
     }
 
     /**


### PR DESCRIPTION
Hi,
In case we want to execute to multiple servers and have the same Envoy script for multiple projects, it's preferable not to modify the list of servers multiple times (once in the servers list and for each task using them) but it should be better to regroup them with a single common name.

Example:
@servers(['bdd' => 'localhost', 'webs' => ['web1', 'web2']])
@task('test2', ['on' => 'webs'])

Thanks