### PR TITLE
Update RunCommand.php

### DIFF
--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -142,7 +142,7 @@ class RunCommand extends \Symfony\Component\Console\Command\Command
      */
     protected function displayOutput($type, $host, $line)
     {
-        $lines = explode(PHP_EOL, $line);
+        $lines = explode('\n', $line);
         foreach($lines as $line) {
             if (strlen(trim($line)) === 0) {
                 return;

--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -142,14 +142,17 @@ class RunCommand extends \Symfony\Component\Console\Command\Command
      */
     protected function displayOutput($type, $host, $line)
     {
-        if (strlen(trim($line)) === 0) {
-            return;
-        }
-
-        if ($type == Process::OUT) {
-            $this->output->write('<comment>['.$host.']</comment>: '.trim($line).PHP_EOL);
-        } else {
-            $this->output->write('<comment>['.$host.']</comment>: <error>'.trim($line).'</error>'.PHP_EOL);
+        $lines = explode(PHP_EOL, $line);
+        foreach($lines as $line) {
+            if (strlen(trim($line)) === 0) {
+                return;
+            }
+    
+            if ($type == Process::OUT) {
+                $this->output->write('<comment>['.$host.']</comment>: '.trim($line).PHP_EOL);
+            } else {
+                $this->output->write('<comment>['.$host.']</comment>: <error>'.trim($line).'</error>'.PHP_EOL);
+            }
         }
     }
 

--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -142,7 +142,7 @@ class RunCommand extends \Symfony\Component\Console\Command\Command
      */
     protected function displayOutput($type, $host, $line)
     {
-        $lines = explode('\n', $line);
+        $lines = explode("\n", $line);
         foreach($lines as $line) {
             if (strlen(trim($line)) === 0) {
                 return;


### PR DESCRIPTION
I noted my 'migrated' messages (and other commands) sometimes broke the return output resulting in:
[localhost]: Migrated: 1970_01_01_000000_create_xxx_table
Migrated:  1970_01_01_000000_create_yyy_table
[localhost]: Migrated: 1970_01_01_000000_create_zzz_table

Maybe my (locally tested) suggestion solves this for other people with a minor OCD.