### PR TITLE
Add username and icon_emoji support for incoming webhooks

### DIFF
--- a/src/Slack.php
+++ b/src/Slack.php
@@ -11,6 +11,8 @@ class Slack
     public $hook;
     public $channel;
     public $message;
+    public $icon_emoji;
+    public $username;
 
     /**
      * Create a new Slack instance.
@@ -20,11 +22,13 @@ class Slack
      * @param  string  $message
      * @return void
      */
-    public function __construct($hook, $channel = '', $message = null)
+    public function __construct($hook, $channel = '', $message = null, $icon_emoji = null, $username = null)
     {
         $this->hook = $hook;
         $this->channel = $channel;
         $this->message = $message;
+        $this->icon_emoji = $icon_emoji;
+        $this->username = $username;
     }
 
     /**
@@ -33,11 +37,13 @@ class Slack
      * @param  string  $hook
      * @param  mixed   $channel
      * @param  string  $message
+     * @param  string  $icon_emoji
+     * @param  string  $username
      * @return \Laravel\Envoy\Slack
      */
-    public static function make($hook, $channel = '', $message = null)
+    public static function make($hook, $channel = '', $message = null, $icon_emoji = null, $username = null)
     {
-        return new static($hook, $channel, $message);
+        return new static($hook, $channel, $message, $icon_emoji, $username);
     }
 
     /**
@@ -50,6 +56,14 @@ class Slack
         $message = $this->message ?: ucwords($this->getSystemUser()).' ran the ['.$this->task.'] task.';
 
         $payload = ['text' => $message, 'channel' => $this->channel];
+        
+        if(!is_null($this->icon_emoji)) {
+            $payload['icon_emoji'] = $this->icon_emoji;
+        }
+        
+        if(!is_null($this->username)) {
+            $payload['username'] = $this->username;
+        }
 
         Request::post("{$this->hook}")->sendsJson()->body($payload)->send();
     }

--- a/src/Slack.php
+++ b/src/Slack.php
@@ -57,11 +57,11 @@ class Slack
 
         $payload = ['text' => $message, 'channel' => $this->channel];
         
-        if(!is_null($this->icon_emoji)) {
+        if(! is_null($this->icon_emoji)) {
             $payload['icon_emoji'] = $this->icon_emoji;
         }
         
-        if(!is_null($this->username)) {
+        if(! is_null($this->username)) {
             $payload['username'] = $this->username;
         }
 


### PR DESCRIPTION
By default nothing has changed. If required the username and icon of the incoming slack message can be changed.

See: https://api.slack.com/incoming-webhooks for more informations about the payload options.