### PR TITLE
Documentation link updated to last available

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,4 +2,4 @@
 
 Elegant SSH tasks for PHP.
 
-Official documentation [is located here](http://laravel.com/docs/5.1/envoy).
+Official documentation [is located here](http://laravel.com/docs/envoy).


### PR DESCRIPTION
The link to the official documentation was updated to always redirect to the last available documentation.
At this moment: https://laravel.com/docs/envoy -> https://laravel.com/docs/5.2/envoy