### PR TITLE
Laravel Envoy now working on Windows

### DIFF
--- a/src/RemoteProcessor.php
+++ b/src/RemoteProcessor.php
@@ -34,8 +34,11 @@ abstract class RemoteProcessor
         // script out to a file or anything. We will start the SSH process then pass
         // these lines of output back to the parent callback for display purposes.
         else {
+            $cmd = '\\' === DIRECTORY_SEPARATOR
+                 ? 'ssh '.$target.' "'.$task->script.'"'
+                 : 'echo \''.'set -e'.PHP_EOL.$task->script.'\' | ssh '.$target.' \'bash -se\'';
             $process = new Process(
-                'echo \''.'set -e'.PHP_EOL.$task->script.'\' | ssh '.$target.' \'bash -se\''
+              $cmd
             );
         }
 


### PR DESCRIPTION
The following information should be included in the docs: ssh comes bundled with Windows 10, not previous versions. If using Windows <10, valid ssh executable should be located somewhere in the path. Git for Windows comes with ssh.exe, or an ssh.bat file can be created to use Plink.