### PR TITLE
Fix RemoteProcess escape/quote issue

### DIFF
--- a/src/RemoteProcessor.php
+++ b/src/RemoteProcessor.php
@@ -35,7 +35,10 @@ abstract class RemoteProcessor
         // these lines of output back to the parent callback for display purposes.
         else {
             $process = new Process(
-                'echo \''.'set -e'.PHP_EOL.$task->script.'\' | ssh '.$target.' \'bash -se\''
+                "ssh $target 'bash -se' << $delimeter".PHP_EOL
+                    .'set -e'.PHP_EOL
+                    .$task->script.PHP_EOL
+                    .$delimeter
             );
         }
 

--- a/src/RemoteProcessor.php
+++ b/src/RemoteProcessor.php
@@ -34,6 +34,7 @@ abstract class RemoteProcessor
         // script out to a file or anything. We will start the SSH process then pass
         // these lines of output back to the parent callback for display purposes.
         else {
+            $delimeter = 'EOF-LARAVEL-ENVOY';
             $process = new Process(
                 "ssh $target 'bash -se' << $delimeter".PHP_EOL
                     .'set -e'.PHP_EOL

--- a/src/RemoteProcessor.php
+++ b/src/RemoteProcessor.php
@@ -36,7 +36,7 @@ abstract class RemoteProcessor
         else {
             $delimeter = 'EOF-LARAVEL-ENVOY';
             $process = new Process(
-                "ssh $target 'bash -se' << $delimeter".PHP_EOL
+                "ssh $target 'bash -se' << \\$delimeter".PHP_EOL
                     .'set -e'.PHP_EOL
                     .$task->script.PHP_EOL
                     .$delimeter


### PR DESCRIPTION
Update RemoteProcessor to use SSH with a heredoc to avoid quoting and escaping issues.