### PR TITLE
Support options without values

### DIFF
--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -16,6 +16,22 @@ class RunCommand extends \Symfony\Component\Console\Command\Command
     use Command;
 
     /**
+     * Command line options that should not be gathered dynamically.
+     *
+     * @var array
+     */
+    protected $staticOptions = [
+        '--pretend',
+        '--help',
+        '--quiet',
+        '--version',
+        '--asci',
+        '--no-asci',
+        '--no-interactions',
+        '--verbose',
+    ];
+
+    /**
      * Configure the command options.
      *
      * @return void
@@ -182,7 +198,7 @@ class RunCommand extends \Symfony\Component\Console\Command\Command
     /**
      * Gather the dynamic options for the command.
      *
-     * @return void
+     * @return array
      */
     protected function getOptions()
     {
@@ -192,11 +208,17 @@ class RunCommand extends \Symfony\Component\Console\Command\Command
         // the double hyphens in front of their name. We will make these available to the
         // Blade task file so they can be used in echo statements and other structures.
         foreach ($_SERVER['argv'] as $argument) {
-            preg_match('/^\-\-(.*?)=(.*)$/', $argument, $match);
-
-            if (count($match) > 0) {
-                $options[$match[1]] = $match[2];
+            if (! starts_with($argument, '--') || in_array($argument, $this->staticOptions)) {
+                continue;
             }
+
+            $option = explode('=', substr($argument, 2));
+
+            if (count($option) == 1) {
+                $option[1] = true;
+            }
+
+            $options[$option[0]] = $option[1];
         }
 
         return $options;


### PR DESCRIPTION
Let's give a little more love to envoy.

Imagine we have a task like this:
```
@task('deploy')
     git pull origin master
     composer install -o
     ...

     @if (!empty($cache))
             // clear cache
     @endif
@endtask
```

```envoy run deploy --cache```  doesn't work.
```envoy run deploy --cache=1``` does, but it's obviously not cool.