### PR TITLE
Allow macros to override their tasks with options.

### DIFF
--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -94,13 +94,15 @@ class RunCommand extends \Symfony\Component\Console\Command\Command
      */
     protected function runTask($container, $task)
     {
-        $confirm = $container->getTask($task)->confirm;
+        $macroOptions = $container->getMacroOptions($this->argument('task'));
+
+        $confirm = $container->getTask($task, $macroOptions)->confirm;
 
         if ($confirm && ! $this->confirmTaskWithUser($task, $confirm)) {
             return;
         }
 
-        if (($exitCode = $this->runTaskOverSSH($container->getTask($task))) > 0) {
+        if (($exitCode = $this->runTaskOverSSH($container->getTask($task, $macroOptions))) > 0) {
             foreach ($container->getErrorCallbacks() as $callback) {
                 call_user_func($callback, $task);
             }

--- a/src/TaskContainer.php
+++ b/src/TaskContainer.php
@@ -56,6 +56,13 @@ class TaskContainer
     protected $taskStack = [];
 
     /**
+     * All of the options for each macro.
+     *
+     * @var array
+     */
+    protected $macroOptions = [];
+
+    /**
      * The stack of macro being rendered.
      *
      * @var array
@@ -209,6 +216,17 @@ class TaskContainer
     }
 
     /**
+     * Get the macro options for the given macro.
+     *
+     * @param  string  $macro
+     * @return array
+     */
+    public function getMacroOptions($macro)
+    {
+        return array_get($this->macroOptions, $macro, []);
+    }
+
+    /**
      * Getter for tasks.
      *
      * @return array
@@ -222,9 +240,10 @@ class TaskContainer
      * Get a Task instance by the given name.
      *
      * @param  string  $task
+     * @param  array  $macroOptions
      * @return string
      */
-    public function getTask($task)
+    public function getTask($task, $macroOptions = [])
     {
         $script = array_get($this->tasks, $task, '');
 
@@ -232,7 +251,7 @@ class TaskContainer
             throw new \Exception(sprintf('Task "%s" is not defined.', $task));
         }
 
-        $options = $this->getTaskOptions($task);
+        $options = array_merge($this->getTaskOptions($task), $macroOptions);
 
         $parallel = array_get($options, 'parallel', false);
 
@@ -273,11 +292,14 @@ class TaskContainer
      * Begin defining a macro.
      *
      * @param  string  $macro
+     * @param  array  $options
      * @return void
      */
-    public function startMacro($macro)
+    public function startMacro($macro, array $options = [])
     {
         ob_start() && $this->macroStack[] = $macro;
+
+        $this->macroOptions[$macro] = $options;
     }
 
     /**


### PR DESCRIPTION
I made this change to allow for flexible reuse of tasks across macros. Any option set by a task can be overruled from the macro. This especially allows for tasks to be applied to specific sets of servers. 

**For example:**

```
@macro('deploy-staging', ['on' => ['stage-1', 'stage-2']])
...
@macro('deploy-production', ['on' => ['web-1', 'web-2']])
```

Both macros in this example would hold the same set of tasks, but they would only run on the servers the macros defined.