### PR TITLE
Fixed ssh user@host when this host already used in ssh config without user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 .DS_Store
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /vendor
 .DS_Store
-.idea

--- a/src/SSHConfigFile.php
+++ b/src/SSHConfigFile.php
@@ -106,7 +106,6 @@ class SSHConfigFile
         foreach ($this->groups as $group) {
             if ((isset($group['host']) && $group['host'] == $host) ||
                 (isset($group['hostname']) && $group['hostname'] == $host)) {
-
                 if (! empty($user)) {
                     // user not specified in ssh config
                     if (! isset($group['user'])) {

--- a/src/SSHConfigFile.php
+++ b/src/SSHConfigFile.php
@@ -106,8 +106,17 @@ class SSHConfigFile
         foreach ($this->groups as $group) {
             if ((isset($group['host']) && $group['host'] == $host) ||
                 (isset($group['hostname']) && $group['hostname'] == $host)) {
-                if (! empty($user) && (! isset($group['user']) || (isset($group['user']) && $group['user'] != $user))) {
-                    continue;
+
+                if (!empty($user)) {
+                    // user not specified in ssh config
+                    if (!isset($group['user'])) {
+                        continue;
+                    }
+
+                    // user specified in ssh config, but not the same
+                    if (isset($group['user']) && $group['user'] != $user) {
+                        continue;
+                    }
                 }
 
                 return $group['host'];

--- a/src/SSHConfigFile.php
+++ b/src/SSHConfigFile.php
@@ -104,9 +104,9 @@ class SSHConfigFile
         list($user, $host) = $this->parseHost($host);
 
         foreach ($this->groups as $group) {
-            if ((isset($group['host']) == $host && $group['host'] == $host) ||
+            if ((isset($group['host']) && $group['host'] == $host) ||
                 (isset($group['hostname']) && $group['hostname'] == $host)) {
-                if (! empty($user) && isset($group['user']) && $group['user'] != $user) {
+                if (! empty($user) && (! isset($group['user']) || (isset($group['user']) && $group['user'] != $user))) {
                     continue;
                 }
 

--- a/src/SSHConfigFile.php
+++ b/src/SSHConfigFile.php
@@ -107,9 +107,9 @@ class SSHConfigFile
             if ((isset($group['host']) && $group['host'] == $host) ||
                 (isset($group['hostname']) && $group['hostname'] == $host)) {
 
-                if (!empty($user)) {
+                if (! empty($user)) {
                     // user not specified in ssh config
-                    if (!isset($group['user'])) {
+                    if (! isset($group['user'])) {
                         continue;
                     }
 


### PR DESCRIPTION
When you use ssh host with local user in your ssh config and trying to use @servers(['prod' => 'www@host']) - envoy uses your local user for ssh.
Commit fixes this problem.