### PR TITLE
Fixed 'The helper "dialog" is not defined' issue

### DIFF
--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -2,8 +2,10 @@
 
 namespace Laravel\Envoy\Console;
 
+use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 trait Command
 {
@@ -52,9 +54,9 @@ trait Command
      */
     public function ask($question)
     {
-        $question = '<comment>'.$question.'</comment> ';
+        $question = new Question('<comment>'.$question.'</comment> ');
 
-        return $this->getHelperSet()->get('dialog')->ask($this->output, $question);
+        return $this->getHelperSet()->get('question')->ask($this->input, $this->output, $question);
     }
 
     /**
@@ -68,9 +70,9 @@ trait Command
     {
         $question = $question === true ? 'Are you sure you want to run the ['.$task.'] task?' : (string) $question;
 
-        $question = '<comment>'.$question.' [y/N]:</comment> ';
+        $question = new ConfirmationQuestion('<comment>'.$question.' [y/N]:</comment> ', false);
 
-        return  $this->getHelperSet()->get('dialog')->askConfirmation($this->output, $question, false);
+        return $this->getHelperSet()->get('question')->ask($this->input, $this->output, $question);
     }
 
     /**
@@ -81,8 +83,11 @@ trait Command
      */
     public function secret($question)
     {
-        $question = '<comment>'.$question.'</comment> ';
+        $question = new Question('<comment>'.$question.'</comment> ');
 
-        return $this->getHelperSet()->get('dialog')->askHiddenResponse($this->output, $question, false);
+        $question->setHidden(true);
+        $question->setHiddenFallback(false);
+
+        return $this->getHelperSet()->get('question')->ask($this->input, $this->output, $question);
     }
 }


### PR DESCRIPTION
Replaced the Dialog helper which was deprecated and removed in Symfony 3.0 by the Question Helper.