### PR TITLE
Initialize template variables

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -66,7 +66,7 @@ class Compiler
             $value = $this->{"compile{$compiler}"}($value);
         }
 
-        return $value;
+        return $this->initializeVariables($value);
     }
 
     /**
@@ -398,6 +398,23 @@ class Compiler
         $pattern = $this->createMatcher('slack');
 
         return preg_replace($pattern, '$1 Laravel\Envoy\Slack::make$2->task($task)->send();', $value);
+    }
+
+    /**
+     * Initialize the variables included in the Envoy template.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    private function initializeVariables($value)
+    {
+        preg_match_all('/\$([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)/', $value, $matches);
+
+        foreach ($matches[0] as $variable) {
+            $value = "<?php $variable = isset($variable) ? $variable : null; ?>\n".$value;
+        }
+
+        return $value;
     }
 
     /**

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -410,7 +410,7 @@ class Compiler
     {
         preg_match_all('/\$([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)/', $value, $matches);
 
-        foreach ($matches[0] as $variable) {
+        foreach (array_unique($matches[0]) as $variable) {
             $value = "<?php $variable = isset($variable) ? $variable : null; ?>\n".$value;
         }
 


### PR DESCRIPTION
We define all variables existing in the template, and check if it's already defined we return it as is, if not we return null.

That way there won't be any undefined variables in the file.

The compiled file will look like this:

```
<?php $test = isset($test) ? $test : null; ?>\n
<?php $message = isset($message) ? $message : null; ?>\n
<?php $__container = isset($__container) ? $__container : null; ?>\n

<?php $__container->servers(['server' => ['localhost']]); ?>\n
...
```