### PR TITLE
Disable pseudo-terminal error message

### DIFF
--- a/src/RemoteProcessor.php
+++ b/src/RemoteProcessor.php
@@ -37,7 +37,7 @@ abstract class RemoteProcessor
             $delimiter = 'EOF-LARAVEL-ENVOY';
 
             $process = new Process(
-                "ssh $target 'bash -se' << \\$delimiter".PHP_EOL
+                "ssh -T $target 'bash -se' << \\$delimiter".PHP_EOL
                     .'set -e'.PHP_EOL
                     .$task->script.PHP_EOL
                     .$delimiter


### PR DESCRIPTION
This small switch can disable one of the most annoying and unnecessary error message on the terminal
(Pseudo-terminal will not be allocated because stdin is not a terminal.)

Screenshot: https://puu.sh/rq9FQ/5894fe4475.png
More information: http://bit.ly/2dBdEJ3