### PR TITLE
Adds symfony 3.x compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     "require": {
         "illuminate/support": "~4.1|~5.0",
         "nategood/httpful": "~0.2",
-        "symfony/console": "~2.3|~3.0",
-        "symfony/process": "~2.3|~3.0"
+        "symfony/console": "~3.0",
+        "symfony/process": "~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8"

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -90,7 +90,7 @@ trait Command
         $question = '<comment>'.$question.'</comment> ';
 
         $question = new Question($question);
-        $question->setHidden($isSecret);
+        $question->setHidden(true);
         $question->setHiddenFallback(false);
 
         return $this->getHelperSet()->get('question')->ask($this->input, $this->output, $question);

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -4,6 +4,8 @@ namespace Laravel\Envoy\Console;
 
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 trait Command
 {
@@ -54,7 +56,9 @@ trait Command
     {
         $question = '<comment>'.$question.'</comment> ';
 
-        return $this->askQuestion($question);
+        $question = new Question($question);
+
+        return $this->getHelperSet()->get('question')->ask($this->input, $this->output, $question);
     }
 
     /**
@@ -70,7 +74,9 @@ trait Command
 
         $question = '<comment>'.$question.' [y/N]:</comment> ';
 
-        return $this->confirmQuestion($question);
+        $question = new ConfirmationQuestion($question, false);
+
+        return $this->getHelperSet()->get('question')->ask($this->input, $this->output, $question);
     }
 
     /**
@@ -83,52 +89,10 @@ trait Command
     {
         $question = '<comment>'.$question.'</comment> ';
 
-        return $this->askQuestion($question, true);
-    }
+        $question = new Question($question);
+        $question->setHidden($isSecret);
+        $question->setHiddenFallback(false);
 
-    /**
-     * Ask the user a question. This method is a compatibilty layer between Symfony versions.
-     * The 'dialog' helper has been deprecated since Symfony 2.5 and is removed from Symfony 3.0 onwards.
-     *
-     * @param string $questionString
-     * @param bool $isSecret
-     *
-     * @return string
-     */
-    protected function askQuestion($questionString, $isSecret = false)
-    {
-        if ($this->getHelperSet()->has('dialog')) {
-            if ($isSecret) {
-                return $this->getHelperSet()->get('dialog')->ask($this->output, $questionString);
-            } else {
-                return $this->getHelperSet()->get('dialog')->askHiddenResponse($this->output, $questionString, false);
-            }
-        } else {
-            $question = new \Symfony\Component\Console\Question\Question($questionString);
-            $question->setHidden($isSecret);
-            $question->setHiddenFallback(false);
-
-            return $this->getHelperSet()->get('question')->ask($this->input, $this->output, $question);
-        }
-    }
-
-    /**
-     * Ask the user for a confirmation. This method is a compatibilty layer between Symfony versions.
-     * The 'dialog' helper has been deprecated since Symfony 2.5 and is removed from Symfony 3.0 onwards.
-     *
-     * @param string $questionString
-     * @param bool $default
-     *
-     * @return string
-     */
-    protected function confirmQuestion($questionString, $default = false)
-    {
-        if ($this->getHelperSet()->has('dialog')) {
-            return $this->getHelperSet()->get('dialog')->askConfirmation($this->output, $questionString, false);
-        } else {
-            $question = new \Symfony\Component\Console\Question\ConfirmationQuestion($questionString, $default);
-
-            return $this->getHelperSet()->get('question')->ask($this->input, $this->output, $question);
-        }
+        return $this->getHelperSet()->get('question')->ask($this->input, $this->output, $question);
     }
 }

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -53,8 +53,7 @@ trait Command
     public function ask($question)
     {
         $question = '<comment>'.$question.'</comment> ';
-
-        return $this->getHelperSet()->get('dialog')->ask($this->output, $question);
+        return $this->askQuestion($question);
     }
 
     /**
@@ -70,7 +69,7 @@ trait Command
 
         $question = '<comment>'.$question.' [y/N]:</comment> ';
 
-        return  $this->getHelperSet()->get('dialog')->askConfirmation($this->output, $question, false);
+        return $this->confirmQuestion($question);
     }
 
     /**
@@ -83,6 +82,55 @@ trait Command
     {
         $question = '<comment>'.$question.'</comment> ';
 
-        return $this->getHelperSet()->get('dialog')->askHiddenResponse($this->output, $question, false);
+        return $this->askQuestion($question, true);
+    }
+
+
+    /**
+     * Ask the user a question. This method is a compatibilty layer between Symfony versions.
+     * The 'dialog' helper has been deprecated since Symfony 2.5 and is removed from Symfony 3.0 onwards.
+     *
+     * @param string $questionString
+     * @param bool $isSecret
+     *
+     * @return string
+     */
+    protected function askQuestion($questionString, $isSecret = false)
+    {
+        if( $this->getHelperSet()->has('dialog') ){
+            if( $isSecret ){
+                return $this->getHelperSet()->get('dialog')->ask($this->output, $questionString);
+            }
+            else{
+                return $this->getHelperSet()->get('dialog')->askHiddenResponse($this->output, $questionString, false);
+            }
+        }
+        else{
+            $question = new \Symfony\Component\Console\Question\Question($questionString);
+            $question->setHidden($isSecret);
+            $question->setHiddenFallback(false);
+
+            return $this->getHelperSet()->get('question')->ask($this->input, $this->output, $question);
+        }
+    }
+
+    /**
+     * Ask the user for a confirmation. This method is a compatibilty layer between Symfony versions.
+     * The 'dialog' helper has been deprecated since Symfony 2.5 and is removed from Symfony 3.0 onwards.
+     *
+     * @param string $questionString
+     * @param bool $default
+     *
+     * @return string
+     */
+    protected function confirmQuestion($questionString, $default = false)
+    {
+        if( $this->getHelperSet()->has('dialog') ){
+            return $this->getHelperSet()->get('dialog')->askConfirmation($this->output, $questionString, false);
+        }
+        else{
+            $question = new \Symfony\Component\Console\Question\ConfirmationQuestion($questionString, $default);
+            return $this->getHelperSet()->get('question')->ask($this->input, $this->output, $question);
+        }
     }
 }

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -53,6 +53,7 @@ trait Command
     public function ask($question)
     {
         $question = '<comment>'.$question.'</comment> ';
+
         return $this->askQuestion($question);
     }
 
@@ -85,7 +86,6 @@ trait Command
         return $this->askQuestion($question, true);
     }
 
-
     /**
      * Ask the user a question. This method is a compatibilty layer between Symfony versions.
      * The 'dialog' helper has been deprecated since Symfony 2.5 and is removed from Symfony 3.0 onwards.
@@ -97,15 +97,13 @@ trait Command
      */
     protected function askQuestion($questionString, $isSecret = false)
     {
-        if( $this->getHelperSet()->has('dialog') ){
-            if( $isSecret ){
+        if ($this->getHelperSet()->has('dialog')) {
+            if ($isSecret) {
                 return $this->getHelperSet()->get('dialog')->ask($this->output, $questionString);
-            }
-            else{
+            } else {
                 return $this->getHelperSet()->get('dialog')->askHiddenResponse($this->output, $questionString, false);
             }
-        }
-        else{
+        } else {
             $question = new \Symfony\Component\Console\Question\Question($questionString);
             $question->setHidden($isSecret);
             $question->setHiddenFallback(false);
@@ -125,11 +123,11 @@ trait Command
      */
     protected function confirmQuestion($questionString, $default = false)
     {
-        if( $this->getHelperSet()->has('dialog') ){
+        if ($this->getHelperSet()->has('dialog')) {
             return $this->getHelperSet()->get('dialog')->askConfirmation($this->output, $questionString, false);
-        }
-        else{
+        } else {
             $question = new \Symfony\Component\Console\Question\ConfirmationQuestion($questionString, $default);
+
             return $this->getHelperSet()->get('question')->ask($this->input, $this->output, $question);
         }
     }


### PR DESCRIPTION
The `composer.json` requirements allows the symfony 3.x components to be used, but the question APIs hasn't been updated to support it, resulting in broken prompts.

The PR adds a compatibility layer by checking the available helpers and use the appropriate one accordingly.

Should fixes the various 'The helper "dialog" is not defined' issues without having to downgrade to 1.1.0.