### PR TITLE
Fix regression for default Slack notification

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -62,11 +62,13 @@ class Compiler
     {
         $compilers = $serversOnly ? $this->serverCompilers : $this->compilers;
 
+        $value = $this->initializeVariables($value);
+
         foreach ($compilers as $compiler) {
             $value = $this->{"compile{$compiler}"}($value);
         }
 
-        return $this->initializeVariables($value);
+        return $value;
     }
 
     /**


### PR DESCRIPTION
When I updated to 1.3.0, I found that my Slack notifications were no longer printing out the task name that had been run (i.e. `Brian ran the [] task.`). I'm using the default Slack message that is created at https://github.com/laravel/envoy/blob/master/src/Slack.php#L54

**A compiled `@after` closure:**
```
<?php 
$_vars = get_defined_vars(); 
$__container->after(function($task) use ($_vars) { 
    extract($_vars); 
    Laravel\Envoy\Slack::make(...);
}); ?>
```

I found that because `$this->initializeVariables($value)` is run after compiling the statements down, a regression was introduced to the compiled $after closures.

**The following is added to the top of the compiled php file:**

```
<?php $_vars = isset($_vars) ? $_vars : null; ?>
<?php $task = isset($task) ? $task : null; ?>
<?php $__container = isset($__container) ? $__container : null; ?>
```

Because `$task` is now being defined at the scope of the script, `$_vars = get_defined_vars();` now overrides the `$task` parameter on the compiled `@after` closure due to the `extract($_vars);` call within.

Moving `$this->initializeVariables($value)` before fixes this regression and limits default initialization to only the variables a user referenced in their blade file.