### PR TITLE
Fix error output

### DIFF
--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -174,7 +174,7 @@ class RunCommand extends \Symfony\Component\Console\Command\Command
 
         foreach ($lines as $line) {
             if (strlen(trim($line)) === 0) {
-                return;
+                continue;
             }
 
             if ($type == Process::OUT) {


### PR DESCRIPTION
If a message comes with a blank line, it ignores all others lines.