### PR TITLE
Add shutdown statement

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -38,6 +38,8 @@ class Compiler
         'TaskStop',
         'After',
         'AfterStop',
+        'Shutdown',
+        'ShutdownStop',
         'Error',
         'ErrorStop',
         'Hipchat',
@@ -350,6 +352,30 @@ class Compiler
     protected function compileAfterStop($value)
     {
         return preg_replace($this->createPlainMatcher('endafter'), '$1}); ?>$2', $value);
+    }
+
+    /**
+     * Compile Envoy shutdown statements into valid PHP.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function compileShutdown($value)
+    {
+        $pattern = $this->createPlainMatcher('shutdown');
+
+        return preg_replace($pattern, '$1<?php $_vars = get_defined_vars(); $__container->shutdown(function() use ($_vars) { extract($_vars); $2', $value);
+    }
+
+    /**
+     * Compile Envoy shutdown stop statements into valid PHP.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function compileShutdownStop($value)
+    {
+        return preg_replace($this->createPlainMatcher('endshutdown'), '$1}); ?>$2', $value);
     }
 
     /**

--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -73,6 +73,10 @@ class RunCommand extends \Symfony\Component\Console\Command\Command
             }
         }
 
+        foreach ($container->getShutdownCallbacks() as $callback) {
+            call_user_func($callback);
+        }
+
         return $exitCode;
     }
 

--- a/src/TaskContainer.php
+++ b/src/TaskContainer.php
@@ -51,6 +51,13 @@ class TaskContainer
     protected $after = [];
 
     /**
+     * All of the "shutdown" callbacks.
+     *
+     * @var array
+     */
+    protected $shutdown = [];
+
+    /**
      * All of the options for each task.
      *
      * @var array
@@ -446,6 +453,27 @@ class TaskContainer
     public function getAfterCallbacks()
     {
         return $this->after;
+    }
+
+    /**
+     * Register an shutdown-task callback.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public function shutdown(Closure $callback)
+    {
+        $this->shutdown[] = $callback;
+    }
+
+    /**
+     * Get all of the shutdown -task callbacks.
+     *
+     * @return array
+     */
+    public function getShutdownCallbacks()
+    {
+        return $this->shutdown;
     }
 
     /**

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Laravel\Envoy;
+
+class CompilerTest extends TestCase
+{
+    public function test_it_compiles_shutdown_statement()
+    {
+        $str = <<<EOL
+@shutdown
+    echo 'shutdown';
+@endshutdown
+EOL;
+        $compiler = new Compiler();
+        $result = $compiler->compile($str);
+        $this->assertEquals(1, preg_match('/\$__container->shutdown\(.*?\}\);/s', $result, $matches));
+    }
+}


### PR DESCRIPTION
Add shutdown statement, this is another approach to resolve #96 .

problem: 
There is no callback for before shutdown.
After statement has been invoked after every task has been done.
If story has many tasks, it makes a bunch of notifications such as hipchat or slack.
I want callbacks for after command has been done.

solution:
I added shutdown statement which is called before shutdown.


I gave up to write tests.
Because it needs mockery and fix TaskContainer and RunCommand to use DI.