### PR TITLE
✨ 💡 Add flag to pass full path to Envoy.blade.php file

### DIFF
--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -45,7 +45,8 @@ class RunCommand extends \Symfony\Component\Console\Command\Command
                 ->setDescription('Run an Envoy task.')
                 ->addArgument('task', InputArgument::REQUIRED)
                 ->addOption('continue', null, InputOption::VALUE_NONE, 'Continue running even if a task fails')
-                ->addOption('pretend', null, InputOption::VALUE_NONE, 'Dump Bash script for inspection');
+                ->addOption('pretend', null, InputOption::VALUE_NONE, 'Dump Bash script for inspection')
+                ->addOption('path', null, InputOption::VALUE_REQUIRED, 'Path to Envoy.blade.php');
     }
 
     /**
@@ -196,7 +197,9 @@ class RunCommand extends \Symfony\Component\Console\Command\Command
      */
     protected function loadTaskContainer()
     {
-        if (! file_exists($envoyFile = getcwd().'/Envoy.blade.php')) {
+        $path = $this->input->getOption('path');
+
+        if (! file_exists($envoyFile = getcwd().'/Envoy.blade.php') && ! file_exists($envoyFile = $path)) {
             echo "Envoy.blade.php not found.\n";
 
             exit(1);


### PR DESCRIPTION
This feature will allow users to override the expectaction that Envoy.blade.php is in the root of the project by supplying the full path on the system to Envoy.blade.php. Alternatively this could be implemented where they give just a path to the folder contianing the file. The current implementation expects the path and the filename.