### PR TITLE
[1.3] Use PSR-1 in PHPunit TestCase

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Envoy;
 
-class TestCase extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+class TestCase extends BaseTestCase
 {
 }


### PR DESCRIPTION
Use PSR-1 while extending PHPUnit TestCase class. This will help us when to migrate to PHPUnit 6, that no longer support snake case namespaces.