### PR TITLE
Allow command line options to contain dashes

### DIFF
--- a/src/TaskContainer.php
+++ b/src/TaskContainer.php
@@ -121,7 +121,11 @@ class TaskContainer
 
         $__container = $this;
 
-        ob_start() && extract($__data);
+        ob_start();
+
+        foreach ($__data as $key => $value) {
+            $$key = $value;
+        }
 
         // Here we will include the compiled Envoy file so it can register tasks into this
         // container instance. Then we will delete the PHP version of the file because

--- a/tests/integration/CommandLineOptionsTest.php
+++ b/tests/integration/CommandLineOptionsTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Laravel\Envoy;
+
+class CommandLineOptionsTest extends TestCase
+{
+    public function test_command_line_option_with_dashes()
+    {
+        $envoy_bin = realpath(__DIR__.'/../../envoy');
+        $working_dir = __DIR__;
+        $task_name = 'test_commmand_line_option_with_dashes';
+        $options = '--command-line-option-with-dashes=foobar';
+        
+        $output = system("cd $working_dir ; $envoy_bin run $task_name $options", $return_val);
+
+        $this->assertEquals(0, $return_val);
+    }
+}

--- a/tests/integration/Envoy.blade.php
+++ b/tests/integration/Envoy.blade.php
@@ -1,0 +1,9 @@
+
+@servers(['local' => ['localhost']])
+
+@task('test_commmand_line_option_with_dashes', ['on' => 'local'])
+    if [ '{{ isset(${'command-line-option-with-dashes'}) ? ${'command-line-option-with-dashes'} : '' }}' != 'foobar' ]
+    then
+        exit 1
+    fi
+@endtask


### PR DESCRIPTION
Re-submitting this pull request with an integration test and a better explanation.

The user can pass variables to tasks with command line options, prefixed with double dashes. E.g:
`$ envoy run deploy --branch=master`

It's a well established that convention that double-dashed CLI option use a dash for word separation, e.g. `$ envoy run deploy --skip-npm-install=true`. Having to use underscores or camelCase for option names doesn't make for a good developer experience.

Problem: when using options with dashes in them, they are silently dropped by [src/TaskContainer.php:124](https://github.com/laravel/envoy/blob/4f11ff314c8337d3dd495e160cbdb34bffa38090/src/TaskContainer.php#L124), because of PHP's `extract()` function.

This pull request simply replaces the call to `extract()` by a `foreach` loop to assign the variables.