### PR TITLE
Allow support for custom filename and multiple envoy files in one folder

### DIFF
--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -46,7 +46,8 @@ class RunCommand extends \Symfony\Component\Console\Command\Command
                 ->addArgument('task', InputArgument::REQUIRED)
                 ->addOption('continue', null, InputOption::VALUE_NONE, 'Continue running even if a task fails')
                 ->addOption('pretend', null, InputOption::VALUE_NONE, 'Dump Bash script for inspection')
-                ->addOption('path', null, InputOption::VALUE_REQUIRED, 'The path to the Envoy.blade.php file');
+                ->addOption('path', null, InputOption::VALUE_REQUIRED, 'The path to the Envoy.blade.php file')
+                ->addOption('file', null, InputOption::VALUE_REQUIRED, 'Set a custom filename (default: Envoy.blade.php)', 'Envoy.blade.php');
     }
 
     /**
@@ -198,9 +199,10 @@ class RunCommand extends \Symfony\Component\Console\Command\Command
     protected function loadTaskContainer()
     {
         $path = $this->input->getOption('path');
+        $filename = $this->input->getOption('file');
 
-        if (! file_exists($envoyFile = $path) && ! file_exists($envoyFile = getcwd().'/Envoy.blade.php')) {
-            echo "Envoy.blade.php not found.\n";
+        if (! file_exists($envoyFile = $path) && ! file_exists($envoyFile = getcwd().'/'.$filename)) {
+            echo "$filename not found.\n";
 
             exit(1);
         }


### PR DESCRIPTION
In some cases we want to use multiple configuration files in one project. For example one main file for deployment and another for updating the local env or some local tasks. 

This wasn't possible because the hardcoded filename `Envoy.blade.php` can exist only once.

With this new option it is possible to load another configuration file like this: `envoy run XXX --file=EnvoyCustom.blade.php`.