### PR TITLE
Add EXTR_SKIP constant to the extract method in after compiler method

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -340,7 +340,7 @@ class Compiler
     {
         $pattern = $this->createPlainMatcher('after');
 
-        return preg_replace($pattern, '$1<?php $_vars = get_defined_vars(); $__container->after(function($task) use ($_vars) { extract($_vars); $2', $value);
+        return preg_replace($pattern, '$1<?php $_vars = get_defined_vars(); $__container->after(function($task) use ($_vars) { extract($_vars, EXTR_SKIP)  ; $2', $value);
     }
 
     /**


### PR DESCRIPTION
Add EXTR_SKIP to the extract() method in the after compiler method so the `$task` variable that is being passed as an attribute is not overwritten if it's being used in the after section or anywhere else.

Here's an example of a case where the value of `task` is being overwritten:

```blade
@servers(['web' => 'some-host'])

@task('run-something')
echo "hi"
@endtask

@error
if ($task == 'run-something') {
echo 'It failed';
}
@enderror

@after
// Here $task will be NULL because the variable $task will be initialized in the initializeVariables method,
// so after the extract() the value passed trough the call_user_func will be overwritten.
@endafter
```