### PR TITLE
Fix path for windows home directory

### DIFF
--- a/src/ConfigurationParser.php
+++ b/src/ConfigurationParser.php
@@ -43,7 +43,7 @@ trait ConfigurationParser
         if (str_contains($system, 'darwin')) {
             return "/Users/{$user}";
         } elseif (str_contains($system, 'windows')) {
-            return "C:\Users\{$user}";
+            return "C:\\Users\\{$user}";
         } elseif (str_contains($system, 'linux')) {
             return "/home/{$user}";
         }


### PR DESCRIPTION
Backslash before curly brace behaves like a slash for escape character, resulting in "**C:\Users\\{user_name}**" instead of "**C:\Users\user_name**" on windows. That in its turn is an incorrect path to the file.