### PR TITLE
Allow to use setup variables inside @error

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -388,7 +388,7 @@ class Compiler
     {
         $pattern = $this->createPlainMatcher('error');
 
-        return preg_replace($pattern, '$1<?php $__container->error(function($task) {$2', $value);
+        return preg_replace($pattern, '$1<?php $_vars = get_defined_vars(); $__container->error(function($task) use ($_vars) { extract($_vars); $2', $value);
     }
 
     /**


### PR DESCRIPTION
Hi,

This PR allow to use variables (define in the `@setup` or passed down through cli) to be accessed and used in the `@error` directive.
