### PR TITLE
Avoid $task overwrite on variables extract in the error callback

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -388,7 +388,7 @@ class Compiler
     {
         $pattern = $this->createPlainMatcher('error');
 
-        return preg_replace($pattern, '$1<?php $_vars = get_defined_vars(); $__container->error(function($task) use ($_vars) { extract($_vars); $2', $value);
+        return preg_replace($pattern, '$1<?php $_vars = get_defined_vars(); $__container->error(function($task) use ($_vars) { extract($_vars, EXTR_SKIP); $2', $value);
     }
 
     /**


### PR DESCRIPTION
Add to the `error` callback the same fix used for the `after` callback.