### PR TITLE
Allow conf option without suffix in file name

### DIFF
--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -202,7 +202,10 @@ class RunCommand extends \Symfony\Component\Console\Command\Command
 
         $file = $this->input->getOption('conf');
 
-        if (! file_exists($envoyFile = $path) && ! file_exists($envoyFile = getcwd().'/'.$file)) {
+        if (! file_exists($envoyFile = $path)
+            && ! file_exists($envoyFile = getcwd().'/'.$file)
+            && ! file_exists($envoyFile .= '.blade.php')
+        ) {
             echo "{$file} not found.\n";
 
             exit(1);


### PR DESCRIPTION
Hi! With this PR, command:

```bash
php -f envoy run foo --conf=EnvoyCustom
```
is the same as command:
```bash
php -f envoy run foo --conf=EnvoyCustom.blade.php
```