### PR TITLE
Add Travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: php
+
+php:
+  - 7.1
+  - 7.2
+  - 7.3
+
+sudo: false
+
+before_install:
+  - phpenv config-rm xdebug.ini || true
+
+install: travis_retry composer install --no-interaction --prefer-dist
+
+script: vendor/bin/phpunit --verbose


### PR DESCRIPTION
I wasn't sure as of which PHP version to start testing since there's no requirement in the composer.json file so I decided to start from the same version as framework. Feel free to adjust to add more versions.

Also don't forget to enable Travis itself.