### PR TITLE
Move envoy cli to bin directory

### DIFF
--- a/bin/envoy
+++ b/bin/envoy
@@ -1,10 +1,10 @@
 #!/usr/bin/env php
 <?php
 
-if (file_exists(__DIR__.'/vendor/autoload.php')) {
-    require __DIR__.'/vendor/autoload.php';
+if (file_exists(__DIR__.'/../vendor/autoload.php')) {
+    require __DIR__.'/../vendor/autoload.php';
 } else {
-    require __DIR__.'/../../autoload.php';
+    require __DIR__.'/../../../autoload.php';
 }
 
 $app = new Symfony\Component\Console\Application('Laravel Envoy', '1.5.0');

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "phpunit/phpunit": "~4.8"
     },
     "bin": [
-        "envoy"
+        "bin/envoy"
     ],
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This is the more common directory for binaries in packages. See https://github.com/php-pds/skeleton_research/blob/1.x/README.md#recommendation for a reference what the common directory structure looks like.