### PR TITLE
Change way of passing commands to ssh process - compability with Windows

### DIFF
--- a/src/RemoteProcessor.php
+++ b/src/RemoteProcessor.php
@@ -37,7 +37,6 @@ abstract class RemoteProcessor
         // script out to a file or anything. We will start the SSH process then pass
         // these lines of output back to the parent callback for display purposes.
         else {
-            $delimiter = 'EOF-LARAVEL-ENVOY';
 
             foreach ($env as $k => $v) {
                 if ($v !== false) {
@@ -46,12 +45,13 @@ abstract class RemoteProcessor
             }
 
             $process = new Process(
-                "ssh $target 'bash -se' << \\$delimiter".PHP_EOL
-                    .implode(PHP_EOL, $env).PHP_EOL
-                    .'set -e'.PHP_EOL
-                    .$task->script.PHP_EOL
-                    .$delimiter
+                "ssh $target"
             );
+
+            $process->setInput(implode(PHP_EOL, $env));
+            $process->setInput('set -e');
+            $process->setInput(str_replace( "\r", PHP_EOL, $task->script ));
+
         }
 
         return [$target, $process->setTimeout(null)];


### PR DESCRIPTION
Previous solution created command string like
```
ssh user@host.com 'bash -se' << \EOF-LARAVEL-ENVOY
    ...
    set -e
    ...commands from task...
    EOF-LARAVEL-ENVOY
```
I was trying to execute `envoy run foo` on Windows to Linux server. As is said in the documentation, library isn't working with Windows. This command string uses [heredoc](http://tldp.org/LDP/abs/html/here-docs.html) which is syntax for Linux, Windows has not equivalent. But we can just pass input to command using `setInput()` from `Symfony\Component\Process\Process`. Thanks to this commands are loaded correctly both Linux bash and Windows cmd. There is no difference in working.
