### PR TITLE
Error code change, if using pretend option.

### DIFF
--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -143,7 +143,7 @@ class RunCommand extends \Symfony\Component\Console\Command\Command
         if ($this->pretending()) {
             echo $task->script.PHP_EOL;
 
-            return 1;
+            return 0;
         } else {
             return $this->passToRemoteProcessor($task);
         }


### PR DESCRIPTION
Changing return code from 1 to 0 if usie pretend option. If it has 0, it will be only print compiled command, and no additional error info. So we can use it to send into bash directly (as alias, for example) and Windows users will have opportunity to use this package with GIT's bash.exe like
`
function envoy-run () {
        A="envoy run --pretend $1 \"${@:2}\""
        echo $($A)
        bash -c "$($A)"
}
`

It is not necessary to use error code 1 in debug printing mode.