### PR TITLE
Drop support for Laravel ~4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "illuminate/support": "~4.1 || ~5.0",
+        "illuminate/support": "~5.0",
         "nategood/httpful": "~0.2",
         "symfony/console": "~3.0 || ~4.0",
         "symfony/process": "~3.0 || ~4.0"


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Right now, some helpers (`Arr::*`) only available from Laravel 5 are used. Since those helpers are not available in Laravel 4, it support should be dropped.

Here's an example of where 

* https://github.com/laravel/envoy/blob/master/src/TaskContainer.php#L198
* https://github.com/laravel/envoy/blob/master/src/TaskContainer.php#L230
* https://github.com/laravel/envoy/blob/master/src/TaskContainer.php#L293