### PR TITLE
Cycle through different colors for each host

### DIFF
--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -34,6 +34,8 @@ class RunCommand extends SymfonyCommand
         '--verbose',
     ];
 
+    protected $hosts = [];
+
     /**
      * Configure the command options.
      *
@@ -179,6 +181,7 @@ class RunCommand extends SymfonyCommand
     protected function displayOutput($type, $host, $line)
     {
         $lines = explode("\n", $line);
+        $coloredHost = $this->getColoredHost($host);
 
         foreach ($lines as $line) {
             if (strlen(trim($line)) === 0) {
@@ -186,9 +189,9 @@ class RunCommand extends SymfonyCommand
             }
 
             if ($type == Process::OUT) {
-                $this->output->write('<comment>['.$host.']</comment>: '.trim($line).PHP_EOL);
+                $this->output->write($coloredHost.': '.trim($line).PHP_EOL);
             } else {
-                $this->output->write('<comment>['.$host.']</comment>: <fg=red>'.trim($line).'</>'.PHP_EOL);
+                $this->output->write($coloredHost.':  '.'<fg=red>'.trim($line).'</>'.PHP_EOL);
             }
         }
     }
@@ -218,6 +221,25 @@ class RunCommand extends SymfonyCommand
         );
 
         return $container;
+    }
+
+    /**
+     * Return the hostname wrapped in a color tag (cycles through 4 colors for each new host)
+     *
+     * @param string $host
+     * @return string
+     */
+    protected function getColoredHost($host)
+    {
+        $colors = ['yellow', 'cyan', 'magenta', 'blue'];
+
+        if (!in_array($host, $this->hosts)) {
+            $this->hosts[] = $host;
+        }
+
+        $color = $colors[array_search($host, $this->hosts) % count($colors)];
+
+        return "<fg=$color>[$host]</>";
     }
 
     /**

--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -224,7 +224,7 @@ class RunCommand extends SymfonyCommand
     }
 
     /**
-     * Return the hostname wrapped in a color tag (cycles through 4 colors for each new host)
+     * Return the hostname wrapped in a color tag (cycles through 4 colors for each new host).
      *
      * @param string $host
      * @return string
@@ -233,7 +233,7 @@ class RunCommand extends SymfonyCommand
     {
         $colors = ['yellow', 'cyan', 'magenta', 'blue'];
 
-        if (!in_array($host, $this->hosts)) {
+        if (! in_array($host, $this->hosts)) {
             $this->hosts[] = $host;
         }
 


### PR DESCRIPTION
Use different colors for each hosts so that it's easier to see which line was output on which host, especially when using parallel execution.

We cycle through yellow, cyan, magenta and blue (red, green and white are already used a lot in the logs themselves so I thought it best not to use them).

Here's a comparison of a deployment on 4 different servers with parallel execution, before and after :

![colored-host](https://user-images.githubusercontent.com/3315078/66749323-d9971c00-ee89-11e9-8a6a-f899495a989c.png)


