### PR TITLE
[1.x] Explode argument option issue losing a part of the argument when multiple = in one line is used

### DIFF
--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -236,7 +236,7 @@ class RunCommand extends \Symfony\Component\Console\Command\Command
                 continue;
             }
 
-            $option = explode('=', substr($argument, 2));
+            $option = explode('=', substr($argument, 2), 2);
 
             if (count($option) == 1) {
                 $option[1] = true;


### PR DESCRIPTION
I have added a limit to the explode of the argument to prevent losing a part of the argument when for example passing a url with query parameters with multiple = values in the argument value.

When passing a URL with query parameters as argument to Envoy, currently it explodes the = value which then is filled back in to the $options array. But by doing this, it losses argument values which has got more than 1 = statement in the argument value.

So for example the following command currently will result in this.

```php
php bin/envoy run foo --argument=http://domain.com?key=value
```

currently results into:

http://domain.com?key

instead of what it should be:

http://domain.com?key=value

So by adding a limit to the following explode

Currently:
```php
$option = explode('=', substr($argument, 2));
```

New:
```php
$option = explode('=', substr($argument, 2), 2);
```

which results in maintaining additional = values in the argument.

http://domain.com?key=value

I have unit tested the current tests and it succeeded, i don't think it will be a issue updating this as the current arguments are still in tact and no changes are made in that.