### PR TITLE
[2.x] Add Telegram notifications support

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -44,6 +44,7 @@ class Compiler
         'ErrorStop',
         'Slack',
         'Discord',
+        'Telegram',
     ];
 
     /**
@@ -426,6 +427,19 @@ class Compiler
         $pattern = $this->createMatcher('discord');
 
         return preg_replace($pattern, '$1 if (! isset($task)) $task = null; Laravel\Envoy\Discord::make$2->task($task)->send();', $value);
+    }
+
+    /**
+     * Compile Envoy Telegram statements into valid PHP.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function compileTelegram($value)
+    {
+        $pattern = $this->createMatcher('telegram');
+
+        return preg_replace($pattern, '$1 if (! isset($task)) $task = null; Laravel\Envoy\Telegram::make$2->task($task)->send();', $value);
     }
 
     /**

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Laravel\Envoy;
+
+use GuzzleHttp\Client;
+
+class Telegram
+{
+    use ConfigurationParser;
+
+    /**
+     * The Bot API Token.
+     *
+     * @var string
+     */
+    public $token;
+
+    /**
+     * The Telegram chat_id.
+     *
+     * @var mixed
+     */
+    public $chat;
+
+    /**
+     * The message.
+     *
+     * @var string
+     */
+    public $message;
+
+    /**
+     * The options.
+     *
+     * @var array
+     */
+    public $options;
+
+    /**
+     * The task name.
+     *
+     * @var string
+     */
+    protected $task;
+
+    /**
+     * Create a new Telegram instance.
+     *
+     * @param  string $token
+     * @param  mixed $chat
+     * @param  string $message
+     * @param  array $options
+     * @return void
+     */
+    public function __construct($token, $chat, $message = null, $options = [])
+    {
+        $this->token = $token;
+        $this->chat = $chat;
+        $this->message = $message;
+        $this->options = $options;
+    }
+
+    /**
+     * Create a new Telegram message instance.
+     *
+     * @param  string $token
+     * @param  string $chat
+     * @param  string $message
+     * @param  array $options
+     * @return \Laravel\Envoy\Telegram
+     */
+    public static function make($token, $chat, $message = null, $options = [])
+    {
+        return new static($token, $chat, $message, $options);
+    }
+
+    /**
+     * Send the Telegram message.
+     *
+     * @return void
+     */
+    public function send()
+    {
+        (new Client())->post($this->getSendMessageEndpoint(), [
+            'json' => $this->buildPayload(),
+        ]);
+    }
+
+    /**
+     * Get the endpoint for the Send request
+     *
+     * @return mixed
+     */
+    private function getSendMessageEndpoint()
+    {
+        return "https://api.telegram.org/bot{$this->token}/sendMessage";
+    }
+
+    /**
+     * Build the payload to send to the endpoint
+     *
+     * @return array
+     */
+    private function buildPayload()
+    {
+        $message = $this->message ?: ($this->task ? ucwords($this->getSystemUser()) . ' ran the [' . $this->task . '] task.' : ucwords($this->getSystemUser()) . ' ran a task.');
+
+        return array_merge(['text' => $message, 'chat_id' => $this->chat], $this->options);
+    }
+
+    /**
+     * Set the task for the message.
+     *
+     * @param  string $task
+     * @return $this
+     */
+    public function task($task)
+    {
+        $this->task = $task;
+
+        return $this;
+    }
+}

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -46,10 +46,10 @@ class Telegram
     /**
      * Create a new Telegram instance.
      *
-     * @param  string $token
-     * @param  mixed $chat
-     * @param  string $message
-     * @param  array $options
+     * @param  string  $token
+     * @param  mixed  $chat
+     * @param  string  $message
+     * @param  array  $options
      * @return void
      */
     public function __construct($token, $chat, $message = null, $options = [])
@@ -63,10 +63,10 @@ class Telegram
     /**
      * Create a new Telegram message instance.
      *
-     * @param  string $token
-     * @param  string $chat
-     * @param  string $message
-     * @param  array $options
+     * @param  string  $token
+     * @param  string  $chat
+     * @param  string  $message
+     * @param  array  $options
      * @return \Laravel\Envoy\Telegram
      */
     public static function make($token, $chat, $message = null, $options = [])
@@ -87,7 +87,7 @@ class Telegram
     }
 
     /**
-     * Get the endpoint for the Send request
+     * Get the endpoint for the Send request.
      *
      * @return mixed
      */
@@ -97,13 +97,13 @@ class Telegram
     }
 
     /**
-     * Build the payload to send to the endpoint
+     * Build the payload to send to the endpoint.
      *
      * @return array
      */
     private function buildPayload()
     {
-        $message = $this->message ?: ($this->task ? ucwords($this->getSystemUser()) . ' ran the [' . $this->task . '] task.' : ucwords($this->getSystemUser()) . ' ran a task.');
+        $message = $this->message ?: ($this->task ? ucwords($this->getSystemUser()).' ran the ['.$this->task.'] task.' : ucwords($this->getSystemUser()).' ran a task.');
 
         return array_merge(['text' => $message, 'chat_id' => $this->chat], $this->options);
     }
@@ -111,7 +111,7 @@ class Telegram
     /**
      * Set the task for the message.
      *
-     * @param  string $task
+     * @param  string  $task
      * @return $this
      */
     public function task($task)


### PR DESCRIPTION
Added support for Telegram notifications using in your `Envoy.blade.php`:

```
@finished
    @telegram('<bot-id>','<chat-id>', '<message = null>', '<options = []>')
@endfinished
```

You should have a proper `<bot-id>`, the id of the bot you're using to send messages. You can get one using an existing Telegram Bot or creating a new one using [BotFather](https://t.me/botfather).
Take a look at [Telegram Docs](https://core.telegram.org/bots/api#authorizing-your-bot) for additional information about Bot ids.

You should also use a valid `<chat-id>`, which is the id of the chat you want to send notifications. You can use the id of your own Telegram account if you want to send messages to yourself through the Bot, or you can use the id of a Telegram group (in which the Bot is invited / present).
You can retrieve the id of your account or of a group in various way: a quick one is using [@username_to_id_bot](https://t.me/username_to_id_bot)

The `message` and `options` params are optional.
Using `message` you can overwrite Envoy default message for a successful task.
Using `options` you can send additional params to Telegram Api.

Resolve Issue: #191

Sending to 2.x branch because I consider it a fully backward compatible minor feature.

Hope this can be useful. Thanks!