### PR TITLE
[2.x] Allow `=` sign to be passed in shell argument values

### DIFF
--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -271,7 +271,7 @@ class RunCommand extends SymfonyCommand
                 $option[1] = true;
             }
 
-            $options[$option[0]] = $option[1];
+            $options[array_shift($option)] = implode('=', $option);
         }
 
         return $options;


### PR DESCRIPTION
### Description
Currently, it is not possible to pass an `=` sign in the shell argument values for envoy.

For example, if we run the following task:

```shell
envoy run task --foo="bar=="
```

The `{{ $foo }}` variable in Blade will be `bar` instead of the intended value `bar==`.