### PR TITLE
Improve assertions

### DIFF
--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -17,6 +17,6 @@ EOL;
         $compiler = new Compiler();
         $result = $compiler->compile($str);
 
-        $this->assertEquals(1, preg_match('/\$__container->finished\(.*?\}\);/s', $result, $matches));
+        $this->assertSame(1, preg_match('/\$__container->finished\(.*?\}\);/s', $result, $matches));
     }
 }

--- a/tests/SSHConfigFileTest.php
+++ b/tests/SSHConfigFileTest.php
@@ -190,7 +190,7 @@ EOT;
         $sshConfig = SSHConfigFile::parseString($config);
         $host = $sshConfig->findConfiguredHost('bar');
 
-        $this->assertEquals('bar', $host);
+        $this->assertSame('bar', $host);
     }
 
     public function test_it_finds_a_matching_host_by_hostname()
@@ -204,7 +204,7 @@ EOT;
         $sshConfig = SSHConfigFile::parseString($config);
         $host = $sshConfig->findConfiguredHost('baz.com');
 
-        $this->assertEquals('bar', $host);
+        $this->assertSame('bar', $host);
     }
 
     public function test_it_returns_null_if_there_are_no_matching_hosts()
@@ -231,7 +231,7 @@ EOT;
         $sshConfig = SSHConfigFile::parseString($config);
         $host = $sshConfig->findConfiguredHost('john@bar');
 
-        $this->assertEquals('bar', $host);
+        $this->assertSame('bar', $host);
     }
 
     public function test_it_returns_null_for_a_matching_host_if_user_specified_and_is_different_from_one_in_config()


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to replace `assertEquals` and it can make assertion equals checking strict.