### PR TITLE
[2.x] Allow hyphenated options

### DIFF
--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -271,7 +271,7 @@ class RunCommand extends SymfonyCommand
                 $option[1] = true;
             }
 
-            $options[$option[0]] = $option[1];
+            $options[Str::camel($option[0])] = $option[1];
         }
 
         return $options;


### PR DESCRIPTION
This change allows for hyphenated options in envoy like so:

```bash
php artisan envoy run foo --no-npm
```

Which can be used as:

```blade
@task('foo', ['on' => 'localhost'])
    @if (! $noNpm)
        npm install
        npm run prod
    @endif

    echo 'Task done'
@endtask
```

Since hyphenated options weren't usable before this won't break direct usage of those. However, it could be considered a breaking change if people were overwriting the command and expecting different keys from the `getOptions` method on the `RunCommand` class. But that seems unlikely to me.

Closes https://github.com/laravel/envoy/issues/211