### PR TITLE
Support for multiple hosts on the same server.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 /phpunit.xml
 .phpunit.result.cache
+.idea/

--- a/src/ParallelSSH.php
+++ b/src/ParallelSSH.php
@@ -23,11 +23,11 @@ class ParallelSSH extends RemoteProcessor
         $callback = $callback ?: function () {
         };
 
-        // Here we will gather all the process instances by host. We will build them in
+        // Here we will gather all the process instances by server name and host combination. We will build them in
         // an array so we can easily loop through them then start them up. We'll key
-        // the array by the target name and set the value as the process instance.
-        foreach ($task->hosts as $host) {
-            $process = $this->getProcess($host, $task);
+        // the array by the target name and and host combination and set the value as the process instance.
+        foreach ($task->servers as $serverName => $host) {
+            $process = $this->getProcess($host, $serverName, $task);
 
             $processes[$process[0]] = $process[1];
         }

--- a/src/SSH.php
+++ b/src/SSH.php
@@ -22,11 +22,11 @@ class SSH extends RemoteProcessor
         $callback = $callback ?: function () {
         };
 
-        // Here we will gather all the process instances by host. We will build them in
+        // Here we will gather all the process instances by server name and host combination. We will build them in
         // an array so we can easily loop through them then start them up. We'll key
-        // the array by the target name and set the value as the process instance.
-        foreach ($task->hosts as $host) {
-            $process = $this->getProcess($host, $task);
+        // the array by the target name and and host combination and set the value as the process instance.
+        foreach ($task->servers as $serverName => $host) {
+            $process = $this->getProcess($host, $serverName, $task);
 
             $processes[$process[0]] = $process[1];
         }

--- a/src/Task.php
+++ b/src/Task.php
@@ -5,11 +5,11 @@ namespace Laravel\Envoy;
 class Task
 {
     /**
-     * All of the hosts to run the task on.
+     * All of the servers to run the task on.
      *
      * @var array
      */
-    public $hosts = [];
+    public $servers = [];
 
     /**
      * The username the task should be run as.
@@ -42,17 +42,17 @@ class Task
     /**
      * Create a new Task instance.
      *
-     * @param  array  $hosts
+     * @param  array  $servers
      * @param  string  $user
      * @param  string  $script
      * @param  bool  $parallel
      * @param  string|null  $confirm
      * @return void
      */
-    public function __construct(array $hosts, $user, $script, $parallel = false, $confirm = null)
+    public function __construct(array $servers, $user, $script, $parallel = false, $confirm = null)
     {
         $this->user = $user;
-        $this->hosts = $hosts;
+        $this->servers = $servers;
         $this->script = $script;
         $this->parallel = $parallel;
         $this->confirm = $confirm;

--- a/src/TaskContainer.php
+++ b/src/TaskContainer.php
@@ -365,9 +365,17 @@ class TaskContainer
             $options['on'] = [];
         }
 
-        return Arr::flatten(array_map(function ($name) {
-            return $this->getServer($name);
-        }, (array) $options['on']));
+        $serverNames = array_map(function ($name) {
+            if (! array_key_exists($name, $this->servers)) {
+                throw new Exception('Server ['.$name.'] is not defined.');
+            }
+
+            return $name;
+        }, (array)$options['on']);
+
+        return array_filter($this->servers, function ($name) use ($serverNames) {
+            return in_array($name, $serverNames);
+        }, ARRAY_FILTER_USE_KEY);
     }
 
     /**


### PR DESCRIPTION
This change allows you to execute tasks on multiple servers with the same remote host.
```
@servers([
'web-1' => ['192.168.1.1'], 
'web-2' => ['192.168.1.1']]
)
@task('deploy', ['on' => ['web-1', 'web-2']])
    pwd
@endtask
```
Previously this configuration would only run once for web-1 , because $processes where keyed by host. I changed it to be keyed by server name and host combination.

There's also a need to be able to navigate to different directories for different hosts on the same server. So I also added `@serverName` and `@serverHost` variables that can be used in tasks to be replaced by actual data before execution. 
For example 
```
@servers([
'web-1' => ['192.168.1.1'], 
'web-2' => ['192.168.1.1']]
)
@task('deploy', ['on' => ['web-1', 'web-2']])
    cd /home/admin/web/@serverName/public_html/
    ....
    supervisorctl stop  @serverName-horizon-worker:*
@endtask
```

Only difference it makes for other use cases is that the server name will also be present in the output.

![image](https://user-images.githubusercontent.com/1502853/107694884-54b05280-6cc9-11eb-9aa1-ad9cf50573d7.png)

