### PR TITLE
[2.x] Add success callbacks

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -40,6 +40,8 @@ class Compiler
         'AfterStop',
         'Finished',
         'FinishedStop',
+        'Success',
+        'SuccessStop',
         'Error',
         'ErrorStop',
         'Slack',
@@ -377,6 +379,30 @@ class Compiler
     protected function compileFinishedStop($value)
     {
         return preg_replace($this->createPlainMatcher('endfinished'), '$1}); ?>$2', $value);
+    }
+    
+    /**
+     * Compile Envoy success statements into valid PHP.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function compileSuccess($value)
+    {
+        $pattern = $this->createPlainMatcher('success');
+
+        return preg_replace($pattern, '$1<?php $_vars = get_defined_vars(); $__container->success(function() use ($_vars) { extract($_vars); $2', $value);
+    }
+
+    /**
+     * Compile Envoy success stop statements into valid PHP.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function compileSuccessStop($value)
+    {
+        return preg_replace($this->createPlainMatcher('endsuccess'), '$1}); ?>$2', $value);
     }
 
     /**

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -380,7 +380,7 @@ class Compiler
     {
         return preg_replace($this->createPlainMatcher('endfinished'), '$1}); ?>$2', $value);
     }
-    
+
     /**
      * Compile Envoy success statements into valid PHP.
      *

--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -83,7 +83,7 @@ class RunCommand extends SymfonyCommand
                 break;
             }
         }
-        
+
         if (! $thisCode) {
             foreach ($container->getSuccessCallbacks() as $callback) {
                 call_user_func($callback);

--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -83,6 +83,12 @@ class RunCommand extends SymfonyCommand
                 break;
             }
         }
+        
+        if (! $thisCode) {
+            foreach ($container->getSuccessCallbacks() as $callback) {
+                call_user_func($callback);
+            }
+        }
 
         foreach ($container->getFinishedCallbacks() as $callback) {
             call_user_func($callback);

--- a/src/TaskContainer.php
+++ b/src/TaskContainer.php
@@ -36,7 +36,7 @@ class TaskContainer
      * @var array
      */
     protected $tasks = [];
-    
+
     /**
      * All of the "success" callbacks.
      *
@@ -487,7 +487,7 @@ class TaskContainer
     {
         return $this->finished;
     }
-    
+
     /**
      * Register an success-task callback.
      *

--- a/src/TaskContainer.php
+++ b/src/TaskContainer.php
@@ -36,6 +36,13 @@ class TaskContainer
      * @var array
      */
     protected $tasks = [];
+    
+    /**
+     * All of the "success" callbacks.
+     *
+     * @var array
+     */
+    protected $success = [];
 
     /**
      * All of the "error" callbacks.
@@ -479,6 +486,27 @@ class TaskContainer
     public function getFinishedCallbacks()
     {
         return $this->finished;
+    }
+    
+    /**
+     * Register an success-task callback.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public function success(Closure $callback)
+    {
+        $this->success[] = $callback;
+    }
+
+    /**
+     * Get all of the success-task callbacks.
+     *
+     * @return array
+     */
+    public function getSuccessCallbacks()
+    {
+        return $this->success;
     }
 
     /**


### PR DESCRIPTION
`@finished` is a catch-all which always runs, regardless of the result.

`@after` runs after each _task_, meaning _stories_ end up firing afters many times.

Currently, only error scenarios are handled discretely via `@error`. There is no explicit compliment to that for a success.

Ideally this would be something like `@success`. Hence this PR