### PR TITLE
[2.x] Pass exit code to finished callbacks

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -365,7 +365,7 @@ class Compiler
     {
         $pattern = $this->createPlainMatcher('finished');
 
-        return preg_replace($pattern, '$1<?php $_vars = get_defined_vars(); $__container->finished(function() use ($_vars) { extract($_vars); $2', $value);
+        return preg_replace($pattern, '$1<?php $_vars = get_defined_vars(); $__container->finished(function($exitCode = null) use ($_vars) { extract($_vars); $2', $value);
     }
 
     /**

--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -85,7 +85,7 @@ class RunCommand extends SymfonyCommand
         }
 
         foreach ($container->getFinishedCallbacks() as $callback) {
-            call_user_func($callback);
+            call_user_func($callback, $exitCode);
         }
 
         return $exitCode;


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
`@finished` is a catch-all which always runs, regardless of the result.

`@after` runs after _each task_, meaning stories end up firing many afters.

Currently, only error scenarios are handled discretely via `@error`. There is no explicit compliment to that for a success.

Ideally this would be something like `@success`. (I've PR'd that too: #219) However, this PR approaches the problem slightly differently by just using the callbacks we already have, not adding more.

### Reusing `@finished`
The finished callbacks currently have very limited context about what's happened at the end of the task or story. While they're useful as a point to fire off alerts and cleanup tasks, the kind of logic you can write around those tasks is limited.

At the very minimum, having access to the **exit code** of the entire execution might be enough to write more useful logic e.g. only sending a 'Deployment completed successfully' message to Slack when the task/story completes with an exit code equivalent to `0`.