### PR TITLE
Add Microsoft Teams notifications

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -47,7 +47,7 @@ class Compiler
         'Slack',
         'Discord',
         'Telegram',
-        'Teams',
+        'MicrosoftTeams',
     ];
 
     /**
@@ -475,11 +475,11 @@ class Compiler
      * @param  string  $value
      * @return string
      */
-    protected function compileTeams($value)
+    protected function compileMicrosoftTeams($value)
     {
-        $pattern = $this->createMatcher('teams');
+        $pattern = $this->createMatcher('microsoftTeams');
 
-        return preg_replace($pattern, '$1 if (! isset($task)) $task = null; Laravel\Envoy\Teams::make$2->task($task)->send();', $value);
+        return preg_replace($pattern, '$1 if (! isset($task)) $task = null; Laravel\Envoy\MicrosoftTeams::make$2->task($task)->send();', $value);
     }
 
     /**

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -47,6 +47,7 @@ class Compiler
         'Slack',
         'Discord',
         'Telegram',
+        'Teams',
     ];
 
     /**
@@ -466,6 +467,19 @@ class Compiler
         $pattern = $this->createMatcher('telegram');
 
         return preg_replace($pattern, '$1 if (! isset($task)) $task = null; Laravel\Envoy\Telegram::make$2->task($task)->send();', $value);
+    }
+
+    /**
+     * Compile Envoy Teams statements into valid PHP.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function compileTeams($value)
+    {
+        $pattern = $this->createMatcher('teams');
+
+        return preg_replace($pattern, '$1 if (! isset($task)) $task = null; Laravel\Envoy\Teams::make$2->task($task)->send();', $value);
     }
 
     /**

--- a/src/MicrosoftTeams.php
+++ b/src/MicrosoftTeams.php
@@ -4,7 +4,7 @@ namespace Laravel\Envoy;
 
 use GuzzleHttp\Client;
 
-class Teams
+class MicrosoftTeams
 {
     use ConfigurationParser;
 
@@ -54,9 +54,9 @@ class Teams
      */
     public function __construct($hook, $message = null, $theme = 'success', $options = [])
     {
-        $this->hook    = $hook;
+        $this->hook = $hook;
         $this->message = $message;
-        $this->theme   = $theme;
+        $this->theme = $theme;
         $this->options = $options;
     }
 
@@ -67,7 +67,7 @@ class Teams
      * @param  string  $message
      * @param  string  $theme
      * @param  array  $options
-     * @return \Laravel\Envoy\Teams
+     * @return \Laravel\Envoy\MicrosoftTeams
      */
     public static function make($hook, $message = null, $theme = 'success', $options = [])
     {
@@ -100,10 +100,10 @@ class Teams
 
         return array_merge(
             [
-                "@context"   => "https://schema.org/extensions",
-                "@type"      => "MessageCard",
+                "@context" => "https://schema.org/extensions",
+                "@type" => "MessageCard",
                 "themeColor" => $this->getTheme(),
-                'text'       => $message
+                'text' => $message
             ],
             $this->options
         );
@@ -118,8 +118,8 @@ class Teams
     {
         $themes = [
             'success' => '#198754',
-            'info'    => '#0dcaf0',
-            'error'   => '#dc3545',
+            'info' => '#0dcaf0',
+            'error' => '#dc3545',
             'warning' => '#fd7e14',
         ];
 

--- a/src/Teams.php
+++ b/src/Teams.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Laravel\Envoy;
+
+use GuzzleHttp\Client;
+
+class Teams
+{
+    use ConfigurationParser;
+
+    /**
+     * The Teams WebHook URL.
+     *
+     * @var string
+     */
+    public $hook;
+
+    /**
+     * The message for Teams Custom Card.
+     *
+     * @var string
+     */
+    public $message;
+
+    /**
+     * The theme color for Teams Custom Card.
+     *
+     * @var string
+     */
+    public $theme;
+    
+    /**
+     * The extra options for Teams Custom Card.
+     *
+     * @var array
+     */
+    public $options;
+
+    /**
+     * The name of the task.
+     *
+     * @var string
+     */
+    protected $task;
+
+    /**
+     * Create a new Teams instance.
+     *
+     * @param  string  $hook
+     * @param  string  $message
+     * @param  string  $theme
+     * @param  array  $options
+     * @return void
+     */
+    public function __construct($hook, $message = null, $theme = 'success', $options = [])
+    {
+        $this->hook    = $hook;
+        $this->message = $message;
+        $this->theme   = $theme;
+        $this->options = $options;
+    }
+
+    /**
+     * Create a new Teams message instance.
+     *
+     * @param  string  $hook
+     * @param  string  $message
+     * @param  string  $theme
+     * @param  array  $options
+     * @return \Laravel\Envoy\Teams
+     */
+    public static function make($hook, $message = null, $theme = 'success', $options = [])
+    {
+        return new static($hook, $message, $theme, $options);
+    }
+
+    /**
+     * Send the Teams message.
+     *
+     * @return void
+     */
+    public function send()
+    {
+        (new Client())->post(
+            $this->hook,
+            [
+                'json' => $this->buildPayload(),
+            ]
+        );
+    }
+
+    /**
+     * Build the payload to send to the webhook.
+     *
+     * @return array
+     */
+    private function buildPayload()
+    {
+        $message = $this->message ?: ($this->task ? ucwords($this->getSystemUser()).' ran the ['.$this->task.'] task.' : ucwords($this->getSystemUser()).' ran a task.');
+
+        return array_merge(
+            [
+                "@context"   => "https://schema.org/extensions",
+                "@type"      => "MessageCard",
+                "themeColor" => $this->getTheme(),
+                'text'       => $message
+            ],
+            $this->options
+        );
+    }
+
+    /**
+     * Get the theme color for Teams Custom Card.
+     *
+     * @return string
+     */
+    private function getTheme(): string
+    {
+        $themes = [
+            'success' => '#198754',
+            'info'    => '#0dcaf0',
+            'error'   => '#dc3545',
+            'warning' => '#fd7e14',
+        ];
+
+        return $themes[$this->theme];
+    }
+
+    /**
+     * Set the task for the message.
+     *
+     * @param  string  $task
+     * @return $this
+     */
+    public function task($task)
+    {
+        $this->task = $task;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
Fixes #222 

This adds supporting of Microsoft Teams notifications. Ex:

```
@finished
    @teams('teams-webhook', 'message = null', 'theme = 'success'', 'options = []')
@endfinished
```
![Screenshot 2021-03-25 032311](https://user-images.githubusercontent.com/8598183/112404785-ac56ca80-8d19-11eb-851e-1beac9fd0250.png)

### Parameters Description:

**teams-webhook:  Required.**
You should create an incoming webhook for the selected channel to receive notifications, check [Teams incoming webhooks](https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook) docs for more information.

**message:  Optional.**
Default value is Envoy default message, but you can overwrite it with your custom message.

**theme:  Optional.**
Default value is `success` for green color, but you can choose from three additional theme:

- `info` for cyan color
- `error` for red color
- `warning` for orange color

**options:  Optional.**
Teams API has many other attributes to customize your message box like title, summary, and sections...
You can use this `options` param. as an array to pass additional attributes to Teams API.