### PR TITLE
Fix trim on windows for listed story tasks when some are preceded by …

### DIFF
--- a/src/TaskContainer.php
+++ b/src/TaskContainer.php
@@ -398,7 +398,7 @@ class TaskContainer
      */
     public function endMacro()
     {
-        $macro = preg_split('/\n|\r\n?/', $this->trimSpaces(trim(ob_get_clean())));
+        $macro = array_map('trim', preg_split('/\n|\r\n?/', $this->trimSpaces(trim(ob_get_clean()))));
 
         $this->macros[array_pop($this->macroStack)] = $macro;
     }


### PR DESCRIPTION
While running envoy from windows command line I had problem with story.
when story tasks are preceded by spaces or tab like below :

```
@story('deploy')
task_1
 task_2
   task_3
    task_4
@endstory
```

On Windows platform, the endMacro() return:
```
array:4 [
  0 => "task_1"
  1 => " task_2"
  2 => "   task_3"
  3 => "    task_4"
]
```
( which is not the case for linux platform )

instead of this for Windows platform :
```
array:4 [
  0 => "task_1"
  1 => "task_2"
  2 => "task_3"
  3 => "task_4"
]
```

This is a fix for that