### PR TITLE
Fix PHP 8.1 deprecation warning

### DIFF
--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -215,7 +215,7 @@ class RunCommand extends SymfonyCommand
      */
     protected function loadTaskContainer()
     {
-        $path = $this->input->getOption('path');
+        $path = $this->input->getOption('path', '');
 
         $file = $this->input->getOption('conf');
 


### PR DESCRIPTION
In PHP 8.1 passing `null` to `file_exists()` is deprecated, so this PR just defaults that option to an empty string if it's not provided.