### PR TITLE
Allow line breaks inside `@server` statements

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -271,7 +271,7 @@ class Compiler
     {
         $pattern = $this->createMatcher('servers');
 
-        return preg_replace($pattern, '$1<?php $__container->servers$2; ?>', $value);
+        return preg_replace($pattern.'s', '$1<?php $__container->servers$2; ?>', $value);
     }
 
     /**

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -33,4 +33,21 @@ EOL;
             $result
         );
     }
+
+    public function test_compile_servers_statement_with_line_breaks()
+    {
+        $str = <<<'EOL'
+@servers([
+    'local' => '127.0.0.1',
+    'remote' => '1.1.1.1',
+])
+EOL;
+        $compiler = new Compiler();
+        $result = $compiler->compile($str);
+
+        $this->assertStringContainsString(
+            "\$__container->servers([\n    'local' => '127.0.0.1',\n    'remote' => '1.1.1.1',\n]);",
+            $result
+        );
+    }
 }

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -19,4 +19,18 @@ EOL;
 
         $this->assertSame(1, preg_match('/\$__container->finished\(.*?\}\);/s', $result, $matches));
     }
+
+    public function test_compile_servers_statement()
+    {
+        $str = <<<'EOL'
+@servers(['local' => '127.0.0.1', 'remote' => '1.1.1.1'])
+EOL;
+        $compiler = new Compiler();
+        $result = $compiler->compile($str);
+
+        $this->assertStringContainsString(
+            "\$__container->servers(['local' => '127.0.0.1', 'remote' => '1.1.1.1']);",
+            $result
+        );
+    }
 }


### PR DESCRIPTION
This PR matches newline characters inside `@server` statements.

**Before:**

```blade
@servers(['local' => '127.0.0.1', 'remote1' => '123.123.123.123', 'remote2' => '234.234.234.234', 'remote3' => '345.345.345.345', 'remote4' => '456.456.456.456'])
```

**After:**

```blade
@servers([
    'local' => '127.0.0.1',
    'remote1' => '123.123.123.123',
    'remote2' => '234.234.234.234',
    'remote3' => '345.345.345.345',
    'remote4' => '456.456.456.456',
    // etc
])
```

I added tests, and this change should be fully backwards compatible because previously a `@server` block with line breaks inside it was ignored.