### PR TITLE
Add `@before` hook

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -36,6 +36,8 @@ class Compiler
         'MacroStop',
         'TaskStart',
         'TaskStop',
+        'Before',
+        'BeforeStop',
         'After',
         'AfterStop',
         'Finished',
@@ -332,6 +334,30 @@ class Compiler
         $pattern = $this->createPlainMatcher('endtask');
 
         return preg_replace($pattern, '$1<?php $__container->endTask(); ?>$2', $value);
+    }
+
+    /**
+     * Compile Envoy before statements into valid PHP.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function compileBefore($value)
+    {
+        $pattern = $this->createPlainMatcher('before');
+
+        return preg_replace($pattern, '$1<?php $_vars = get_defined_vars(); $__container->before(function($task) use ($_vars) { extract($_vars, EXTR_SKIP)  ; $2', $value);
+    }
+
+    /**
+     * Compile Envoy before stop statements into valid PHP.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function compileBeforeStop($value)
+    {
+        return preg_replace($this->createPlainMatcher('endbefore'), '$1}); ?>$2', $value);
     }
 
     /**

--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -131,6 +131,10 @@ class RunCommand extends SymfonyCommand
             return;
         }
 
+        foreach ($container->getBeforeCallbacks() as $callback) {
+            call_user_func($callback, $task);
+        }
+
         if (($exitCode = $this->runTaskOverSSH($container->getTask($task, $macroOptions))) > 0) {
             foreach ($container->getErrorCallbacks() as $callback) {
                 call_user_func($callback, $task);

--- a/src/TaskContainer.php
+++ b/src/TaskContainer.php
@@ -52,6 +52,13 @@ class TaskContainer
     protected $error = [];
 
     /**
+     * All of the "before" callbacks.
+     *
+     * @var array
+     */
+    protected $before = [];
+
+    /**
      * All of the "after" callbacks.
      *
      * @var array
@@ -444,6 +451,27 @@ class TaskContainer
         } else {
             $this->tasks[$name] = $contents;
         }
+    }
+
+    /**
+     * Register a before-task callback.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public function before(Closure $callback)
+    {
+        $this->before[] = $callback;
+    }
+
+    /**
+     * Get all of the before-task callbacks.
+     *
+     * @return array
+     */
+    public function getBeforeCallbacks()
+    {
+        return $this->before;
     }
 
     /**

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -19,4 +19,17 @@ EOL;
 
         $this->assertSame(1, preg_match('/\$__container->finished\(.*?\}\);/s', $result, $matches));
     }
+
+    public function test_compile_before_statement()
+    {
+        $str = <<<'EOL'
+@before
+    echo "Running {{ $task }} task.";
+@endbefore
+EOL;
+        $compiler = new Compiler();
+        $result = $compiler->compile($str);
+
+        $this->assertSame(1, preg_match('/\$__container->before\(.*?\}\);/s', $result, $matches));
+    }
 }


### PR DESCRIPTION
This PR adds a new `@before` hook, identical to `@after` except that it runs before each task. Like `@after` and `@error` it receives the name of the task.

```blade
@before
    if ($task === 'finalize_release') {
        echo "Almost done!";
    }
@endbefore
```

My use case for this is outputting a friendly description of each task in a long story as it runs, without having the commands to echo out the messages cluttering up the beginning of every single task. I imagine there are lots of other uses for it too, like waiting for something to become available before starting a task, or making an initial measurement and then doing before/after comparisons when a task is finished.

If this PR is accepted I'll add this to the docs too.