### PR TITLE
[2.x] Revert allowing line breaks inside `@server` statements

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -273,7 +273,7 @@ class Compiler
     {
         $pattern = $this->createMatcher('servers');
 
-        return preg_replace($pattern.'s', '$1<?php $__container->servers$2; ?>', $value);
+        return preg_replace($pattern, '$1<?php $__container->servers$2; ?>', $value);
     }
 
     /**

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -20,37 +20,6 @@ EOL;
         $this->assertSame(1, preg_match('/\$__container->finished\(.*?\}\);/s', $result, $matches));
     }
 
-    public function test_compile_servers_statement()
-    {
-        $str = <<<'EOL'
-@servers(['local' => '127.0.0.1', 'remote' => '1.1.1.1'])
-EOL;
-        $compiler = new Compiler();
-        $result = $compiler->compile($str);
-
-        $this->assertStringContainsString(
-            "\$__container->servers(['local' => '127.0.0.1', 'remote' => '1.1.1.1']);",
-            $result
-        );
-    }
-
-    public function test_compile_servers_statement_with_line_breaks()
-    {
-        $str = <<<'EOL'
-@servers([
-    'local' => '127.0.0.1',
-    'remote' => '1.1.1.1',
-])
-EOL;
-        $compiler = new Compiler();
-        $result = $compiler->compile($str);
-
-        $this->assertStringContainsString(
-            "\$__container->servers([\n    'local' => '127.0.0.1',\n    'remote' => '1.1.1.1',\n]);",
-            $result
-        );
-    }
-
     public function test_compile_before_statement()
     {
         $str = <<<'EOL'


### PR DESCRIPTION
This PR reverts #241 for now. It breaks if there is another `)` character anywhere after the `@servers` block (which there almost definitely will be) because the `@servers` block now matches up to that last parenthesis.

E.g. this breaks completely because of the `)` in the setup section:

```blade
@servers(['local' => 'localhost', 'staging' => 'staging-host'])
@setup
    $releaseName = date('Y-m-d_H-i-s');
@endsetup
```

Sorry about this! I'll keep working on the regex and PR something more robust if I figure it out.