### PR TITLE
[2.x] Add user and shell configuration

### DIFF
--- a/src/RemoteProcessor.php
+++ b/src/RemoteProcessor.php
@@ -33,10 +33,9 @@ abstract class RemoteProcessor
 
         $shell = $task->shell ?: 'bash';
 
-        if (!empty($task->user)) {
-            $shell = 'sudo -u '. escapeshellarg($task->user) . ' '. $shell;
+        if (! empty($task->user)) {
+            $shell = 'sudo -u '.escapeshellarg($task->user).' '.$shell;
         }
-
 
         if (in_array($target, ['local', 'localhost', '127.0.0.1'])) {
             $process = Process::fromShellCommandline("{$shell} -se << \\$delimiter".PHP_EOL
@@ -48,7 +47,6 @@ abstract class RemoteProcessor
         // script out to a file or anything. We will start the SSH process then pass
         // these lines of output back to the parent callback for display purposes.
         else {
-
             foreach ($env as $k => $v) {
                 if ($v !== false) {
                     $env[$k] = 'export '.$k.'="'.$v.'"'.PHP_EOL;

--- a/src/RemoteProcessor.php
+++ b/src/RemoteProcessor.php
@@ -39,7 +39,7 @@ abstract class RemoteProcessor
 
 
         if (in_array($target, ['local', 'localhost', '127.0.0.1'])) {
-            $process = Process::fromShellCommandline($shell." -se << \\$delimiter".PHP_EOL
+            $process = Process::fromShellCommandline("{$shell} -se << \\$delimiter".PHP_EOL
                 .$task->script.PHP_EOL
                 .$delimiter, null, $env);
         }

--- a/src/Task.php
+++ b/src/Task.php
@@ -57,7 +57,7 @@ class Task
      * @param  string|null  $confirm
      * @return void
      */
-    public function __construct(array $hosts, $user, $shell, $script, $parallel = false, $confirm = null)
+    public function __construct(array $hosts, $user, $script, $parallel = false, $confirm = null, $shell = null)
     {
         $this->user = $user;
         $this->shell = $shell;

--- a/src/Task.php
+++ b/src/Task.php
@@ -19,6 +19,13 @@ class Task
     public $user;
 
     /**
+     * The shell the task should be run with.
+     *
+     * @var string
+     */
+    public $shell;
+
+    /**
      * The script commands.
      *
      * @var string
@@ -44,14 +51,16 @@ class Task
      *
      * @param  array  $hosts
      * @param  string  $user
+     * @param  string  $shell
      * @param  string  $script
      * @param  bool  $parallel
      * @param  string|null  $confirm
      * @return void
      */
-    public function __construct(array $hosts, $user, $script, $parallel = false, $confirm = null)
+    public function __construct(array $hosts, $user, $shell, $script, $parallel = false, $confirm = null)
     {
         $this->user = $user;
+        $this->shell = $shell;
         $this->hosts = $hosts;
         $this->script = $script;
         $this->parallel = $parallel;

--- a/src/TaskContainer.php
+++ b/src/TaskContainer.php
@@ -175,7 +175,7 @@ class TaskContainer
      */
     protected function replaceSubTasks()
     {
-        foreach ($this->tasks as $name => &$script) {
+        foreach ($this->tasks as &$script) {
             $callback = function ($m) {
                 return $m[1].$this->tasks[$m[2]];
             };
@@ -353,7 +353,7 @@ class TaskContainer
 
         $confirm = Arr::get($options, 'confirm', null);
 
-        return new Task($this->getServers($options), $options['as'], $script, $parallel, $confirm);
+        return new Task($this->getServers($options), $options['as'], $options['shell'], $script, $parallel, $confirm);
     }
 
     /**
@@ -432,7 +432,7 @@ class TaskContainer
      */
     protected function mergeDefaultOptions(array $options)
     {
-        return array_merge(['as' => null, 'on' => array_keys($this->servers)], $options);
+        return array_merge(['as' => null, 'shell' => null, 'on' => array_keys($this->servers)], $options);
     }
 
     /**

--- a/src/TaskContainer.php
+++ b/src/TaskContainer.php
@@ -353,7 +353,7 @@ class TaskContainer
 
         $confirm = Arr::get($options, 'confirm', null);
 
-        return new Task($this->getServers($options), $options['as'], $options['shell'], $script, $parallel, $confirm);
+        return new Task($this->getServers($options), $options['as'], $script, $parallel, $confirm, $options['shell']);
     }
 
     /**

--- a/tests/E2ETest.php
+++ b/tests/E2ETest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Laravel\Envoy\Tests;
+
+use closure;
+use PHPUnit\Framework\TestCase;
+
+class E2ETest extends TestCase
+{
+    public function fixtures(): array {
+        $data = [];
+        foreach (scandir(__DIR__.'/fixtures') as $file) {
+            $fullPath = __DIR__.'/fixtures/'.$file;
+            if (str_ends_with($file, '.blade.php')) {
+                $spec = __DIR__.'/fixtures/'.str_replace('blade.php', 'spec.php', $file);
+                if (is_file($spec)) {
+                    $specs = require $spec;
+                    foreach ($specs as $task => $func) {
+                        $data[] = [$file, $task, $func];
+                    }
+                }
+            }
+        }
+        return $data;
+    }
+
+    /**
+     * @dataProvider fixtures
+     */
+    public function testFixtures(string $file, string $task, closure $func) {
+        exec(__DIR__ . "/../bin/envoy run --path tests/fixtures/{$file} {$task}", $output, $code);
+        $func->call($this, $output, $code);
+    }
+}

--- a/tests/E2ETest.php
+++ b/tests/E2ETest.php
@@ -7,7 +7,8 @@ use PHPUnit\Framework\TestCase;
 
 class E2ETest extends TestCase
 {
-    public function fixtures(): array {
+    public function fixtures(): array
+    {
         $data = [];
         foreach (scandir(__DIR__.'/fixtures') as $file) {
             $fullPath = __DIR__.'/fixtures/'.$file;
@@ -21,14 +22,16 @@ class E2ETest extends TestCase
                 }
             }
         }
+
         return $data;
     }
 
     /**
      * @dataProvider fixtures
      */
-    public function testFixtures(string $file, string $task, closure $func) {
-        exec(__DIR__ . "/../bin/envoy run --path tests/fixtures/{$file} {$task}", $output, $code);
+    public function testFixtures(string $file, string $task, closure $func)
+    {
+        exec(__DIR__."/../bin/envoy run --path tests/fixtures/{$file} {$task}", $output, $code);
         $func->call($this, $output, $code);
     }
 }

--- a/tests/fixtures/ShellAs.blade.php
+++ b/tests/fixtures/ShellAs.blade.php
@@ -1,0 +1,18 @@
+@servers(['local' => '127.0.0.1'])
+
+@task('test_as', ['as' => 'root'])
+whoami
+@endtask
+
+@task('test_shell_bash', ['shell' => '/bin/bash'])
+ps -p $$ | tail -n1 | awk '{ print $4; }'
+@endtask
+
+@task('test_shell_sh', ['shell' => '/bin/sh'])
+ps -p $$ | tail -n1 | awk '{ print $4; }'
+@endtask
+
+@task('test_as_shell', ['as' => 'root', 'shell' => '/bin/bash'])
+whoami
+ps -p $$ | tail -n1 | awk '{ print $4; }'
+@endtask

--- a/tests/fixtures/ShellAs.spec.php
+++ b/tests/fixtures/ShellAs.spec.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+    'test_as' => function ($output) {
+        $this->assertEquals([
+            '[127.0.0.1]: root'
+        ], $output);
+    },
+    'test_shell_sh' => function ($output) {
+        $this->assertEquals([
+            '[127.0.0.1]: sh'
+        ], $output);
+    },
+    'test_shell_bash' => function ($output) {
+        $this->assertEquals([
+            '[127.0.0.1]: bash'
+        ], $output);
+    },
+    'test_as_shell' => function ($output) {
+        $this->assertEquals([
+            '[127.0.0.1]: root',
+            '[127.0.0.1]: bash'
+        ], $output);
+    },
+];

--- a/tests/fixtures/ShellAs.spec.php
+++ b/tests/fixtures/ShellAs.spec.php
@@ -3,23 +3,23 @@
 return [
     'test_as' => function ($output) {
         $this->assertEquals([
-            '[127.0.0.1]: root'
+            '[127.0.0.1]: root',
         ], $output);
     },
     'test_shell_sh' => function ($output) {
         $this->assertEquals([
-            '[127.0.0.1]: sh'
+            '[127.0.0.1]: sh',
         ], $output);
     },
     'test_shell_bash' => function ($output) {
         $this->assertEquals([
-            '[127.0.0.1]: bash'
+            '[127.0.0.1]: bash',
         ], $output);
     },
     'test_as_shell' => function ($output) {
         $this->assertEquals([
             '[127.0.0.1]: root',
-            '[127.0.0.1]: bash'
+            '[127.0.0.1]: bash',
         ], $output);
     },
 ];

--- a/tests/fixtures/Story.blade.php
+++ b/tests/fixtures/Story.blade.php
@@ -1,0 +1,27 @@
+@servers(['local' => '127.0.0.1'])
+
+@story('story_1')
+task_1
+task_3
+@endstory
+
+@story('story_2')
+task_2
+task_3
+@endstory
+
+@task('task_1')
+echo 1
+@endtask
+
+@task('task_2')
+echo 2
+@endtask
+
+@task('task_3')
+echo 3
+@endtask
+
+@finished
+echo "finished";
+@endfinished

--- a/tests/fixtures/Story.spec.php
+++ b/tests/fixtures/Story.spec.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+    'story_1' => function ($output, $code) {
+        $this->assertEquals(0, $code);
+        $this->assertEquals([
+            '[127.0.0.1]: 1',
+            '[127.0.0.1]: 3',
+            'finished',
+        ], $output);
+    },
+    'story_2' => function ($output, $code) {
+        $this->assertEquals(0, $code);
+        $this->assertEquals([
+            '[127.0.0.1]: 2',
+            '[127.0.0.1]: 3',
+            'finished',
+        ], $output);
+    },
+];


### PR DESCRIPTION
This PR fixes #245, because it would run on bash on ssh (see bash -e in the code) but not on localhost
Some scripts would then behave differently when run on localhost, this defaults to bash on localhost as well and adds the options to change the shell in both ssh and localhost

During development I also noticed that the `as` option had been added since the beggining (see https://github.com/laravel/envoy/blame/1eb1e129bd3eca5513928352cfd4368afbb12c57/src/Task.php#L17) but never actually used anywhere, so this PR also adds this features

# Features

- [x] Run as specific user on linux 
- [ ] Run as specific user on windows (feasible with `runas /user:administrator` but will ask for user password, not the case with sudo NOPASSWD, might need separate option for password input)
- [x] Run in a specific shell on linux  
- [ ] Run in a specific shell on windows (powershell or cmd)
- [ ] Detect correct implementation based on remote OS and requested shell (Currently it's assumed that the remote ssh runs the same OS as the script running envoy, it might not be the case)

# Tests
- [x] Build a E2E test framework
- [x] Tests for added features
- [ ] Other tests for existing features 
- [ ] Tests for different environment and with ssh (windows, linux etc)
