### PR TITLE
[3.x] Fix Story & Task option merge priority

### DIFF
--- a/src/TaskContainer.php
+++ b/src/TaskContainer.php
@@ -340,7 +340,7 @@ class TaskContainer
             throw new Exception(sprintf('Task "%s" is not defined.', $task));
         }
 
-        $options = array_merge($this->getTaskOptions($task), $macroOptions);
+        $options = array_merge($macroOptions, $this->getTaskOptions($task));
 
         $parallel = Arr::get($options, 'parallel', false);
 


### PR DESCRIPTION
See #248

Consider the following

```php
@servers(['local' => 'localhost', 'dev' => 'someserver'])

@story('deploy', ['on' => 'dev'])
task_1
task_2
@endstory

@task('task_1')
echo 'task_1';
@endtask

@task('task_2', ['on' => 'local'])
echo 'task_2';
@endtask
```

Currently `task_2` will be executed on the remote server instead of the expected localhost because the story options have priority over the task options but the behavior should be the opposite because a task is more specific than a story

After this PR the task options will correctly override the story options and `task_1` will be executed on dev and `task_2` on local

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->


<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
