### PR TITLE
Fix hostname returned when multiple host aliases are defined

### DIFF
--- a/src/SSHConfigFile.php
+++ b/src/SSHConfigFile.php
@@ -120,7 +120,7 @@ class SSHConfigFile
                     }
                 }
 
-                return $group['host'];
+                return preg_replace('/\s+.*$/', '', $group['host']);
             }
         }
     }

--- a/tests/SSHConfigFileTest.php
+++ b/tests/SSHConfigFileTest.php
@@ -247,6 +247,20 @@ EOT;
         $this->assertNull($host);
     }
 
+    public function test_it_returns_valid_host_for_multiple_aliased_hosts()
+    {
+        $config = <<<'EOT'
+Host foo bar baz
+Hostname baz.com
+User john
+EOT;
+        $sshConfig = SSHConfigFile::parseString($config);
+        $host = $sshConfig->findConfiguredHost('baz.com');
+
+        // Really, any one of the host's aliases would work
+        $this->assertContains($host, ['foo', 'bar', 'baz']);
+    }
+
     private function parse($config)
     {
         $sshConfig = SSHConfigFile::parseString($config);


### PR DESCRIPTION
Hosts with multiple aliases were returning invalid hostnames.

For example, given config:

```
Host foo bar baz
  HostName 127.0.0.1
```

When running `->findConfiguredHost('127.0.0.1')`, `'foo bar baz'` was getting returned which is invalid. With this change, the hostname returned will be `'foo'` (valid).

Also updated tests.

Fixes #230
