### PR TITLE
Add $__task so available in @setup

### DIFF
--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -234,7 +234,7 @@ class RunCommand extends SymfonyCommand
         }
 
         with($container = new TaskContainer)->load(
-            $envoyFile, new Compiler, $this->getOptions()
+            $envoyFile, new Compiler, $this->argument('task'), $this->getOptions()
         );
 
         return $container;

--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -234,7 +234,10 @@ class RunCommand extends SymfonyCommand
         }
 
         with($container = new TaskContainer)->load(
-            $envoyFile, new Compiler, $this->argument('task'), $this->getOptions()
+            $envoyFile,
+            new Compiler,
+            $this->argument('task'),
+            array_merge($this->getOptions(), ['__task' => $this->argument('task')])
         );
 
         return $container;

--- a/src/TaskContainer.php
+++ b/src/TaskContainer.php
@@ -111,7 +111,7 @@ class TaskContainer
      */
     public function loadServers($path, Compiler $compiler)
     {
-        return $this->load($path, $compiler, [], true);
+        $this->load($path, $compiler, '', [], true);
     }
 
     /**
@@ -119,11 +119,12 @@ class TaskContainer
      *
      * @param  string  $__path
      * @param  \Laravel\Envoy\Compiler  $__compiler
+     * @param  string  $taskName
      * @param  array  $__data
      * @param  bool  $__serversOnly
      * @return void
      */
-    public function load($__path, Compiler $__compiler, array $__data = [], $__serversOnly = false)
+    public function load($__path, Compiler $__compiler, string $taskName = '', array $__data = [], $__serversOnly = false)
     {
         $__dir = realpath(dirname($__path));
 
@@ -135,6 +136,7 @@ class TaskContainer
         );
 
         $__container = $this;
+        $__taskName = $taskName;
 
         ob_start() && extract($__data);
 
@@ -252,7 +254,7 @@ class TaskContainer
             throw new InvalidArgumentException("Unable to locate file: [{$file}].");
         }
 
-        $this->load($path, new Compiler, $data);
+        $this->load($path, new Compiler, '', $data);
     }
 
     /**

--- a/src/TaskContainer.php
+++ b/src/TaskContainer.php
@@ -111,7 +111,7 @@ class TaskContainer
      */
     public function loadServers($path, Compiler $compiler)
     {
-        $this->load($path, $compiler, '', [], true);
+        $this->load($path, $compiler, [], true);
     }
 
     /**
@@ -119,12 +119,11 @@ class TaskContainer
      *
      * @param  string  $__path
      * @param  \Laravel\Envoy\Compiler  $__compiler
-     * @param  string  $taskName
      * @param  array  $__data
      * @param  bool  $__serversOnly
      * @return void
      */
-    public function load($__path, Compiler $__compiler, string $taskName = '', array $__data = [], $__serversOnly = false)
+    public function load($__path, Compiler $__compiler, array $__data = [], $__serversOnly = false)
     {
         $__dir = realpath(dirname($__path));
 
@@ -136,7 +135,6 @@ class TaskContainer
         );
 
         $__container = $this;
-        $__taskName = $taskName;
 
         ob_start() && extract($__data);
 
@@ -254,7 +252,7 @@ class TaskContainer
             throw new InvalidArgumentException("Unable to locate file: [{$file}].");
         }
 
-        $this->load($path, new Compiler, '', $data);
+        $this->load($path, new Compiler, $data);
     }
 
     /**

--- a/src/TaskContainer.php
+++ b/src/TaskContainer.php
@@ -111,7 +111,7 @@ class TaskContainer
      */
     public function loadServers($path, Compiler $compiler)
     {
-        $this->load($path, $compiler, [], true);
+        return $this->load($path, $compiler, [], true);
     }
 
     /**


### PR DESCRIPTION
Add the variable `$__taskName` so you can get the current task/storyname in the @setup directive. Now you don't have to specify extra variables when creating multiple stories. Example:

> When running `envoy run deploy`, that you can get `deploy`. And when you run `envoy run deploy_backend` you can get `deploy_backend`
> 
> 
> ```
> @servers(['localhost' => '127.0.0.1'])
> 
> @setup
>    $releaseDir = $baseDir . '/releases/'.date('YmdHis');
> 
>    if($__taskName === 'deploy_backend') {
>       $releaseDir =  $baseDir . '/current';
>    }
> 
> @endsetup
> 
> // Complete deploy, create new folder and check project, run composer, npm etc.
> @story('deploy')
>    git_clone
>    commontask_1
>    commontask_2
>    ....
> @endstory
> 
> // Only update backend, pull backend in current dir and restart application, migrations etc.
> @story('deploy_backend')
>    git_pull
>    commontask_1
>    commontask_2
>    ...
> @endstory
> ```

Fixes https://github.com/laravel/envoy/issues/253