### PR TITLE
Fix STDERR Output

### DIFF
--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -188,27 +188,23 @@ class RunCommand extends SymfonyCommand
     /**
      * Display the given output line.
      *
-     * @param  int  $type
+     * @param  string  $type
      * @param  string  $host
      * @param  string  $line
      * @return void
      */
     protected function displayOutput($type, $host, $line)
     {
-        $lines = explode("\n", $line);
+        $lines = array_filter(array_map('trim', explode("\n", $line)));
 
         $hostColor = $this->getHostColor($host);
 
         foreach ($lines as $line) {
-            if (strlen(trim($line)) === 0) {
-                continue;
+            if ($type === Process::ERR) {
+                $line = '<fg=red>'.$line.'</>';
             }
 
-            if ($type == Process::OUT) {
-                $this->output->write($hostColor.': '.trim($line).PHP_EOL);
-            } else {
-                $this->output->write($hostColor.':  '.'<fg=red>'.trim($line).'</>'.PHP_EOL);
-            }
+            $this->output->write($hostColor.': '.$line.PHP_EOL);
         }
     }
 


### PR DESCRIPTION
There was an extra space before STDERR output. This PR makes all the output line up.

Envoy.blade.php to reproduce the error
```
@servers(['localhost' => '127.0.0.1'])

@task('output')
    echo "standard output"
    echo "error output" >&2
@endtask
```

Before change:
![image](https://user-images.githubusercontent.com/3212673/202335028-c256f135-d234-42d8-9c94-b49d81476021.png)

After change:
![image](https://user-images.githubusercontent.com/3212673/202334903-a2460c2e-8a9e-4586-a7a3-8c32a97a549c.png)
