### PR TITLE
Add input and output properties to Command

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [7.2, 7.3, 7.4, '8.0', 8.1, 8.2]
-        laravel: [6, 7, 8]
+        laravel: [6, 7, 8, 9]
         exclude:
           - php: 7.2
             laravel: 8

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -10,6 +10,20 @@ use Symfony\Component\Console\Question\Question;
 trait Command
 {
     /**
+     * The console command input.
+     *
+     * @var array
+     */
+    protected $input;
+
+    /**
+     * The console command output.
+     *
+     * @var array
+     */
+    protected $output;
+
+    /**
      * Execute the command.
      *
      * @param  \Symfony\Component\Console\Input\InputInterface  $input


### PR DESCRIPTION
Fixes https://github.com/laravel/envoy/issues/258

Seems like Envoy was also missing a Laravel v9 build.