### PR TITLE
[2.x] Compile `@servers` When Array is in Multiple Lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 /phpunit.xml
 .phpunit.result.cache
+.idea

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -271,7 +271,7 @@ class Compiler
      */
     protected function compileServers($value)
     {
-        $value = preg_replace_callback('/@servers\(\[(.*?)\]\)/s', function($matches) {
+        $value = preg_replace_callback('/@servers\(\[(.*?)\]\)/s', function ($matches) {
             return "@servers([" . preg_replace('/\s+/', '', $matches[1]) . "])";
         }, $value);
 

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -271,6 +271,10 @@ class Compiler
      */
     protected function compileServers($value)
     {
+        $value = preg_replace_callback('/@servers\(\[(.*?)\]\)/s', function($matches) {
+            return "@servers([" . preg_replace('/\s+/', '', $matches[1]) . "])";
+        }, $value);
+
         $pattern = $this->createMatcher('servers');
 
         return preg_replace($pattern, '$1<?php $__container->servers$2; ?>', $value);

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -272,7 +272,7 @@ class Compiler
     protected function compileServers($value)
     {
         $value = preg_replace_callback('/@servers\(\[(.*?)\]\)/s', function ($matches) {
-            return "@servers([" . preg_replace('/\s+/', '', $matches[1]) . "])";
+            return '@servers(['.preg_replace('/\s+/', '', $matches[1]).'])';
         }, $value);
 
         $pattern = $this->createMatcher('servers');

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -32,4 +32,39 @@ EOL;
 
         $this->assertSame(1, preg_match('/\$__container->before\(.*?\}\);/s', $result, $matches));
     }
+
+    public function test_it_compiles_server_statement()
+    {
+        $str = <<<'EOL'
+@servers([
+    'foo' => 'bar'
+])
+EOL;
+        $compiler = new Compiler();
+        $result = $compiler->compile($str);
+
+        $this->assertSame($result, "<?php \$__container->servers(['foo'=>'bar']); ?>");
+
+        $str = <<<'EOL'
+@servers([
+    'foo' => [
+        'bar',
+        'baz',
+        'bah'
+    ]
+])
+EOL;
+        $compiler = new Compiler();
+        $result = $compiler->compile($str);
+
+        $this->assertSame($result, "<?php \$__container->servers(['foo'=>['bar','baz','bah']]); ?>");
+
+        $str = <<<'EOL'
+@servers(['foo' => 'bar'])
+EOL;
+        $compiler = new Compiler();
+        $result = $compiler->compile($str);
+
+        $this->assertSame($result, "<?php \$__container->servers(['foo'=>'bar']); ?>");
+    }
 }

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -60,6 +60,17 @@ EOL;
         $this->assertSame($result, "<?php \$__container->servers(['foo'=>['bar','baz','bah']]); ?>");
 
         $str = <<<'EOL'
+@servers([
+    'foo' => ['bar'],
+    'bar' => ['baz']
+])
+EOL;
+        $compiler = new Compiler();
+        $result = $compiler->compile($str);
+
+        $this->assertSame($result, "<?php \$__container->servers(['foo'=>['bar'],'bar'=>['baz']]); ?>");
+
+        $str = <<<'EOL'
 @servers(['foo' => 'bar'])
 EOL;
         $compiler = new Compiler();


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This pull request aims to introduce the ability to compile the `@servers` when the array is in multiple lines, fixing the issue mentioned in #209 

```blade
@servers([
    'foo' => [
        'bar',
        'baz',
        'bah'
    ]
])
```

The implemented code ensures that the current format still becomes usable:

```blade
@servers(['foo' => 'bar'])
```

A simple test was introduced to validate the feature.

## Note

The `.idea` folder was introduced into `.gitignore`