### PR TITLE
Add Google Chat

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -50,6 +50,7 @@ class Compiler
         'Discord',
         'Telegram',
         'MicrosoftTeams',
+        'GoogleChat',
     ];
 
     /**
@@ -510,6 +511,19 @@ class Compiler
         $pattern = $this->createMatcher('microsoftTeams');
 
         return preg_replace($pattern, '$1 if (! isset($task)) $task = null; Laravel\Envoy\MicrosoftTeams::make$2->task($task)->send();', $value);
+    }
+
+    /**
+     * Compile Envoy GoogleChat statements into valid PHP.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function compileGoogleChat($value)
+    {
+        $pattern = $this->createMatcher('googleChat');
+
+        return preg_replace($pattern, '$1 if (! isset($task)) $task = null; Laravel\Envoy\GoogleChat::make$2->task($task)->send();', $value);
     }
 
     /**

--- a/src/GoogleChat.php
+++ b/src/GoogleChat.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Laravel\Envoy;
+
+use GuzzleHttp\Client;
+
+class GoogleChat
+{
+    use ConfigurationParser;
+
+    /**
+     * The webhook URL.
+     *
+     * @var string
+     */
+    public $hook;
+
+    /**
+     * The message.
+     *
+     * @var string
+     */
+    public $message;
+
+    /**
+     * The options.
+     *
+     * @var array
+     */
+    public $options;
+
+    /**
+     * The task name.
+     *
+     * @var string
+     */
+    protected $task;
+
+    /**
+     * Create a new Google Chat instance.
+     *
+     * @param  string  $hook
+     * @param  string  $message
+     * @param  array  $options
+     * @return void
+     */
+    public function __construct($hook, $message = null, $options = [])
+    {
+        $this->hook = $hook;
+        $this->message = $message;
+        $this->options = $options;
+    }
+
+    /**
+     * Create a new Google Chat message instance.
+     *
+     * @param  string  $hook
+     * @param  string  $message
+     * @param  array  $options
+     * @return \Laravel\Envoy\GoogleChat
+     */
+    public static function make($hook, $message = null, $options = [])
+    {
+        return new static($hook, $message, $options);
+    }
+
+    /**
+     * Send the Google Chat message.
+     *
+     * @return void
+     */
+    public function send()
+    {
+        $message = $this->message ?: ($this->task ? ucwords($this->getSystemUser()).' ran the ['.$this->task.'] task.' : ucwords($this->getSystemUser()).' ran a task.');
+
+        $payload = array_merge(['text' => $message], $this->options);
+
+        (new Client())->post($this->hook, [
+            'json' => $payload,
+        ]);
+    }
+
+    /**
+     * Set the task for the message.
+     *
+     * @param  string  $task
+     * @return $this
+     */
+    public function task($task)
+    {
+        $this->task = $task;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
This PR adds support for Google Chat notifications.

Currently major platforms are supported, however, I think Google Chat is missing and could be very beneficial for many users. The implementation is similar to the existing ones.

Here is an example:

```php
@success
    @googleChat($webhookUrl, 'hola')
@endsuccess
```

And this is the result in Google Chat

![image](https://github.com/user-attachments/assets/41d88a99-94e8-4efe-9714-5b8c31217fa3)
