### PR TITLE
Allow calling stories from other stories

### DIFF
--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -109,13 +109,12 @@ class RunCommand extends SymfonyCommand
     }
 
     /**
-     * Build a list of tasks starting from a task or macro name. When $task points to a macro
-     * we will pull the tasks from it, else we simply add the task to the list.
+     * Build a list of tasks starting from a task or macro name.
      *
-     * @param  array  $tasks  The current list of tasks
+     * @param  array  $tasks
      * @param  \Laravel\Envoy\TaskContainer  $container
-     * @param  string  $task  The name of the task
-     * @return array The updated list of tasks
+     * @param  string  $task
+     * @return array
      */
     protected function buildTaskList($container, $task, $tasks = []): array
     {

--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -123,7 +123,7 @@ class RunCommand extends SymfonyCommand
             foreach ($macro as $task) {
                 $tasks = $this->buildTaskList($container, $task, $tasks);
             }
-            
+
             return $tasks;
         }
 

--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -105,15 +105,30 @@ class RunCommand extends SymfonyCommand
      */
     protected function getTasks($container)
     {
-        $tasks = [$task = $this->argument('task')];
-
-        if ($macro = $container->getMacro($task)) {
-            $tasks = $macro;
-        }
-
-        return $tasks;
+        return $this->buildTaskList($container, $this->argument('task'));
     }
 
+    /**
+     * Build a list of tasks starting from a task or macro name. When $task points to a macro
+     * we will pull the tasks from it, else we simply add the task to the list. 
+     *
+     * @param  array                         $tasks     The current list of tasks
+     * @param  \Laravel\Envoy\TaskContainer  $container 
+     * @param  string                        $task      The name of the task 
+     * @return array The updated list of tasks
+     */
+    protected function buildTaskList($container, $task, $tasks = []): array
+    {
+        if ($macro = $container->getMacro($task)) {
+            foreach ($macro as $task) {
+                $tasks = $this->addTasks($container, $task, $tasks);
+            }
+            return $tasks;
+        }
+
+        return [...$tasks, $task];
+    }
+    
     /**
      * Run the given task out of the container.
      *

--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -110,25 +110,26 @@ class RunCommand extends SymfonyCommand
 
     /**
      * Build a list of tasks starting from a task or macro name. When $task points to a macro
-     * we will pull the tasks from it, else we simply add the task to the list. 
+     * we will pull the tasks from it, else we simply add the task to the list.
      *
-     * @param  array                         $tasks     The current list of tasks
-     * @param  \Laravel\Envoy\TaskContainer  $container 
-     * @param  string                        $task      The name of the task 
+     * @param  array  $tasks  The current list of tasks
+     * @param  \Laravel\Envoy\TaskContainer  $container
+     * @param  string  $task  The name of the task
      * @return array The updated list of tasks
      */
     protected function buildTaskList($container, $task, $tasks = []): array
     {
         if ($macro = $container->getMacro($task)) {
             foreach ($macro as $task) {
-                $tasks = $this->addTasks($container, $task, $tasks);
+                $tasks = $this->buildTaskList($container, $task, $tasks);
             }
+            
             return $tasks;
         }
 
         return [...$tasks, $task];
     }
-    
+
     /**
      * Run the given task out of the container.
      *


### PR DESCRIPTION
fixes https://github.com/laravel/envoy/issues/149

Proposed way to do that is simply to recursively inspect the list of tasks returned by a macro in order to extract the real tasks from it (and if a macro is encountered, unfold its content and append it to the list of tasks).

I found no tests for the command and hence did not write anything specific for that.

To test this improvement, one can have the following script:

```
@task('task-1')
    ln -al
@endtask

@task('task-2')
    pwd
@endtask

@story('story-1')
    task-1
    task-2
@endstory
    
@story('story-2')
    task-1
    task-2
    story-1
@endstory
```

When running `story-1`, on should see consecutively `task-1`, `task-2`.

When running `story-2`, on should see consecutively `task-1`, `task-2`, `task-1`, `task-2`.