### PR TITLE
Add macro-level before and after callback support

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -350,7 +350,7 @@ class Compiler
     {
         $pattern = $this->createPlainMatcher('before');
 
-        return preg_replace($pattern, '$1<?php $_vars = get_defined_vars(); $__container->before(function($task) use ($_vars) { extract($_vars, EXTR_SKIP)  ; $2', $value);
+        return preg_replace($pattern, '$1<?php $_vars = get_defined_vars(); $__container->before(function($task, $macro) use ($_vars) { extract($_vars, EXTR_SKIP)  ; $2', $value);
     }
 
     /**
@@ -374,7 +374,7 @@ class Compiler
     {
         $pattern = $this->createPlainMatcher('after');
 
-        return preg_replace($pattern, '$1<?php $_vars = get_defined_vars(); $__container->after(function($task) use ($_vars) { extract($_vars, EXTR_SKIP)  ; $2', $value);
+        return preg_replace($pattern, '$1<?php $_vars = get_defined_vars(); $__container->after(function($task, $macro) use ($_vars) { extract($_vars, EXTR_SKIP)  ; $2', $value);
     }
 
     /**

--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -119,8 +119,16 @@ class RunCommand extends SymfonyCommand
     protected function buildTaskList($container, $task, $tasks = []): array
     {
         if ($macro = $container->getMacro($task)) {
+            foreach ($container->getBeforeCallbacks() as $callback) {
+                call_user_func($callback, null, $task);
+            }
+
             foreach ($macro as $task) {
                 $tasks = $this->buildTaskList($container, $task, $tasks);
+            }
+
+            foreach ($container->getAfterCallbacks() as $callback) {
+                call_user_func($callback, null, $task);
             }
 
             return $tasks;

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -20,7 +20,7 @@ EOL;
         $this->assertSame(1, preg_match('/\$__container->finished\(.*?\}\);/s', $result, $matches));
     }
 
-    public function test_compile_before_statement()
+    public function test_compile_before_statement(): void
     {
         $str = <<<'EOL'
 @before
@@ -29,8 +29,23 @@ EOL;
 EOL;
         $compiler = new Compiler();
         $result = $compiler->compile($str);
-
+ 
         $this->assertSame(1, preg_match('/\$__container->before\(.*?\}\);/s', $result, $matches));
+        $this->assertStringContainsString('function($task, $macro)', $result);
+    }
+
+   public function test_compile_after_statement(): void 
+    {
+        $str = <<<'EOL'
+@after
+    echo "Running {{ $task }} task.";
+@endafter
+EOL;
+        $compiler = new Compiler();
+        $result = $compiler->compile($str);
+ 
+        $this->assertSame(1, preg_match('/\$__container->after\(.*?\}\);/s', $result, $matches));
+        $this->assertStringContainsString('function($task, $macro)', $result);
     }
 
     public function test_it_compiles_server_statement()


### PR DESCRIPTION
Adds macro-level before and after callback support. Callbacks now receive both $task and $macro parameters to differentiate between task and macro execution.

Example Usage

```blade
@before
  if ($macro === 'deploy') {
      // Run critical tests before deployment
      if (!runTests()) {
          throw new Exception('Tests failed - deployment aborted');
      }
  }
@endbefore

@macro('deploy')
    test
    build
    deploy
@endmacro
```

Changes

- Updated callback signatures to include $macro parameter
- Added macro-level callback execution in buildTaskList()
- Maintains backward compatibility
