### PR TITLE
Update Symfony deps versions to support v8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         "php": "^7.2|^8.0",
         "guzzlehttp/guzzle": "^6.0|^7.0",
         "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
-        "symfony/console": "^4.3|^5.0|^6.0|^7.0",
-        "symfony/process": "^4.3|^5.0|^6.0|^7.0"
+        "symfony/console": "^4.3|^5.0|^6.0|^7.0|^8.0",
+        "symfony/process": "^4.3|^5.0|^6.0|^7.0|^8.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.10",


### PR DESCRIPTION
Updates Symfony versions to allow v8. without this , the installation fails on laravel 13 projects.