### PR TITLE
[2.x] Fix workflow YAML syntax and remove no-op composer require

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - *.x
+      - '*.x'
   pull_request:
   schedule:
     - cron: '0 0 * * *'
@@ -80,7 +80,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require  --no-update
           composer update --prefer-dist --no-interaction --no-progress --with="illuminate/contracts=^${{ matrix.laravel }}"
 
       - name: Execute tests (display deprecations)


### PR DESCRIPTION
## Summary

The tests workflow has been broken since **2026-02-20** when PR #289 (Laravel 13.x Compatibility) accidentally unquoted the `'*.x'` branch pattern. Every test run since then has been instantly rejected by GitHub Actions — **5 weeks of no CI coverage**.

### Root cause

The L13 compatibility PR changed `'*.x'` to `*.x` in the `branches` list. In YAML, `*` is a reserved character (alias node indicator), causing GitHub Actions to reject the workflow file. The quotes were correct before and got removed during the edit.

### Fix

1. **Re-quote `*.x` to `'*.x'`** — restores the branch pattern that was working before PR #289
2. **Remove the no-op `composer require --no-update`** line — this has been in the workflow for a while with no package argument. Composer silently ignores it (exits 0), so it's not causing failures, but it's dead code that looks like a bug.

### CI result

All **30/30 matrix jobs pass** — PHP 7.2–8.4 × Laravel 6–13.