### PR TITLE
Add void return type hints to console commands

### DIFF
--- a/src/Console/InitCommand.php
+++ b/src/Console/InitCommand.php
@@ -14,7 +14,7 @@ class InitCommand extends SymfonyCommand
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('init')

--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -46,7 +46,7 @@ class RunCommand extends SymfonyCommand
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this->ignoreValidationErrors();
 

--- a/src/Console/SshCommand.php
+++ b/src/Console/SshCommand.php
@@ -19,7 +19,7 @@ class SshCommand extends SymfonyCommand
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('ssh')

--- a/src/Console/TasksCommand.php
+++ b/src/Console/TasksCommand.php
@@ -15,7 +15,7 @@ class TasksCommand extends SymfonyCommand
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('tasks')
                 ->setDescription('Lists all Envoy tasks and macros.');


### PR DESCRIPTION
Improves type safety and ensures compatibility with `Symfony\Component\Console\Command\Command::configure(): void` to fix #294