### PR TITLE
Fix high CPU usage when running tasks in parallel

### DIFF
--- a/src/ParallelSSH.php
+++ b/src/ParallelSSH.php
@@ -40,9 +40,7 @@ class ParallelSSH extends RemoteProcessor
         while ($this->areRunning($processes)) {
             $this->gatherOutput($processes, $callback);
 
-            // The status and output checks above do not block, so we will sleep
-            // for a moment to avoid pinning a CPU core while we wait for these
-            // processes to finish running out on their respective machines.
+            // Sleep to avoid pinning CPU core while we wait...
             usleep(1000);
         }
 

--- a/src/ParallelSSH.php
+++ b/src/ParallelSSH.php
@@ -39,6 +39,11 @@ class ParallelSSH extends RemoteProcessor
 
         while ($this->areRunning($processes)) {
             $this->gatherOutput($processes, $callback);
+
+            // The status and output checks above do not block, so we will sleep
+            // for a moment to avoid pinning a CPU core while we wait for these
+            // processes to finish running out on their respective machines.
+            usleep(1000);
         }
 
         // Finally, we'll gather the output one last time to make sure no more output is


### PR DESCRIPTION
Running a task across multiple servers with `parallel` spins a CPU core at 100% for the entire duration of the task. `ParallelSSH::run()` polls the processes in a `while` loop, but both `isRunning()` and `getIncrementalOutput()` are non-blocking, so the loop never yields.

This adds a 1ms `usleep()` to the loop, matching the throttle Symfony's own [`Process::wait()`](https://github.com/symfony/process/blob/v6.4.33/Process.php#L430-L432) uses for the same `while ($this->isRunning())` polling pattern. CPU usage drops to near zero with no meaningful change to output latency. The non-parallel `SSH` runner is unaffected since it already goes through `Process::run()`.

The test setup, on > 1 server, just "sleep" on the remote;

```php
Envoy.blade.php
@servers([
    's1' => 'forge@server1.tld',
    's2' => 'forge@server2.tld',
])

@task('spin', ['on' => ['s1', 's2'], 'parallel' => true])
    sleep 25
@endtask
```

<img width="1278" height="110" alt="CleanShot 2026-06-30 at 20 21 38@2x" src="https://github.com/user-attachments/assets/d34eb294-4539-4598-a809-9f4acfd56e45" />

This pegs a CPU on the deploying machine (the source) to 100% CPU for the duration of the sleep, this patch prevents that entirely.