### PR TITLE
Fix parsing native options after dynamic options

### DIFF
--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -48,8 +48,6 @@ class RunCommand extends SymfonyCommand
      */
     protected function configure(): void
     {
-        $this->ignoreValidationErrors();
-
         $this->setName('run')
                 ->setDescription('Run an Envoy task.')
                 ->addArgument('task', InputArgument::REQUIRED)
@@ -57,6 +55,22 @@ class RunCommand extends SymfonyCommand
                 ->addOption('pretend', null, InputOption::VALUE_NONE, 'Dump Bash script for inspection')
                 ->addOption('path', null, InputOption::VALUE_REQUIRED, 'The path to the Envoy.blade.php file')
                 ->addOption('conf', null, InputOption::VALUE_REQUIRED, 'The name of the Envoy file', 'Envoy.blade.php');
+
+        foreach ($_SERVER['argv'] as $argument) {
+            if (! Str::startsWith($argument, '--')) {
+                continue;
+            }
+
+            $option = explode('=', substr($argument, 2), 2);
+
+            if (! $this->getDefinition()->hasOption($option[0])) {
+                $this->addOption(
+                    $option[0],
+                    null,
+                    count($option) === 1 ? InputOption::VALUE_NONE : InputOption::VALUE_REQUIRED
+                );
+            }
+        }
     }
 
     /**

--- a/tests/RunCommandTest.php
+++ b/tests/RunCommandTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Laravel\Envoy\Tests;
+
+use Laravel\Envoy\Console\RunCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class RunCommandTest extends TestCase
+{
+    /**
+     * @dataProvider optionOrders
+     */
+    public function test_native_and_dynamic_options_are_parsed_in_any_order(array $arguments): void
+    {
+        $this->runCommand($arguments, function ($input) {
+            $this->assertSame('example-task', $input->getArgument('task'));
+            $this->assertTrue($input->getOption('pretend'));
+            $this->assertTrue($input->getOption('continue'));
+            $this->assertSame('recipes', $input->getOption('path'));
+            $this->assertSame('Deploy.blade.php', $input->getOption('conf'));
+            $this->assertSame('check', $input->getOption('mode'));
+        });
+    }
+
+    public static function optionOrders(): array
+    {
+        return [
+            'dynamic before native' => [[
+                'example-task', '--mode=check', '--pretend', '--continue',
+                '--path=recipes', '--conf=Deploy.blade.php',
+            ]],
+            'dynamic between native' => [[
+                'example-task', '--pretend', '--mode=check', '--continue',
+                '--path=recipes', '--conf=Deploy.blade.php',
+            ]],
+            'dynamic after native' => [[
+                'example-task', '--pretend', '--continue', '--path=recipes',
+                '--conf=Deploy.blade.php', '--mode=check',
+            ]],
+        ];
+    }
+
+    public function test_boolean_and_value_dynamic_options_are_parsed(): void
+    {
+        $this->runCommand(['example-task', '--force', '--mode=check'], function ($input) {
+            $this->assertTrue($input->getOption('force'));
+            $this->assertSame('check', $input->getOption('mode'));
+        });
+    }
+
+    public function test_absent_native_options_keep_their_defaults(): void
+    {
+        $this->runCommand(['example-task', '--mode=check'], function ($input) {
+            $this->assertFalse($input->getOption('pretend'));
+            $this->assertFalse($input->getOption('continue'));
+            $this->assertNull($input->getOption('path'));
+            $this->assertSame('Envoy.blade.php', $input->getOption('conf'));
+        });
+    }
+
+    /**
+     * @dataProvider invalidNativeOptions
+     */
+    public function test_invalid_native_option_values_are_rejected(array $arguments, string $message): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage($message);
+
+        $this->runCommand($arguments, function () {
+        });
+    }
+
+    public static function invalidNativeOptions(): array
+    {
+        return [
+            'missing path value' => [['example-task', '--mode=check', '--path'], 'The "--path" option requires a value'],
+            'missing conf value' => [['example-task', '--mode=check', '--conf'], 'The "--conf" option requires a value'],
+            'pretend value' => [['example-task', '--mode=check', '--pretend=yes'], 'The "--pretend" option does not accept a value'],
+            'continue value' => [['example-task', '--mode=check', '--continue=yes'], 'The "--continue" option does not accept a value'],
+            'excess argument' => [['example-task', '--mode=check', 'unexpected'], 'Too many arguments'],
+        ];
+    }
+
+    private function runCommand(array $arguments, callable $callback): void
+    {
+        $_SERVER['argv'] = array_merge(['envoy', 'run'], $arguments);
+
+        $command = new TestRunCommand($callback);
+        $input = new ArgvInput(array_merge(['envoy'], $arguments));
+
+        $command->run($input, new BufferedOutput);
+    }
+}
+
+class TestRunCommand extends RunCommand
+{
+    private $callback;
+
+    public function __construct(callable $callback)
+    {
+        $this->callback = $callback;
+
+        parent::__construct();
+    }
+
+    protected function fire()
+    {
+        ($this->callback)($this->input);
+
+        return 0;
+    }
+}


### PR DESCRIPTION
Fixes #308.

### Motivation
- Symfony stopped parsing when encountering unknown dynamic options, causing native options that followed (e.g. `--pretend`, `--continue`, `--path`, `--conf`) to be ignored; this produced a silent regression in option handling. 
- The goal is to ensure dynamic options are registered before Symfony validation so native options are parsed correctly regardless of ordering.

### Description
- Remove the call to `ignoreValidationErrors()` and instead register dynamic CLI options found in `$_SERVER['argv']` before Symfony parses the input by adding them via `$this->addOption(...)` in `RunCommand::configure()`. 
- New logic inspects each `--...` argument, splits `key`/`value` on `=`, and registers unknown options as either `VALUE_NONE` (boolean) or `VALUE_REQUIRED` (value). 
- Add `tests/RunCommandTest.php` with data-driven cases covering dynamic-before-native, dynamic-between-native, dynamic-after-native orders, boolean and valued dynamic options, absent native options defaults, and invalid/extra-value cases.

### Testing
- Installed dependencies: ran `composer install --no-interaction --prefer-dist` and verified success (`COMPOSER_INSTALL_EXIT=0`).
- Verified PHPUnit binary exists via `test -x vendor/bin/phpunit` (exit `0`).
- Full test suite on patched code: `vendor/bin/phpunit` — result: exit `0`, all tests passed (30 tests, 57 assertions) with one PHPUnit deprecation about XML schema (non-fatal). 
- Regression check on the parent commit (`78f14b9`) by applying the new test into a worktree and running the single test: `/tmp/envoy-parent/vendor/bin/phpunit -c /tmp/envoy-parent/phpunit.xml.dist --filter 'test_native_and_dynamic_options_are_parsed_in_any_order.*dynamic before native' /tmp/envoy-parent/tests/RunCommandTest.php` — result: failing on the parent (exit non-zero); observed failure message: "Failed asserting that false is true." which shows `--pretend` was not parsed as `true` when it appeared after a dynamic option. 
- Same single test on the patched code: `vendor/bin/phpunit --filter 'test_native_and_dynamic_options_are_parsed_in_any_order.*dynamic before native' tests/RunCommandTest.php` — result: exit `0` (test passes). 
- Notes: PHPUnit reported one deprecation recommending migration of `phpunit.xml.dist` schema; this does not affect the correctness of the patch. The test matrix (Symfony Console v8.1.4 and PHPUnit 10.5.64 in this environment) ran the full suite and the regression checks successfully on the patched code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a850c7d6db8832c860b9a7d6961aacd)