### PR TITLE
Fix concurrent Envoy invocations racing on the compiled recipe file

### DIFF
--- a/src/TaskContainer.php
+++ b/src/TaskContainer.php
@@ -141,9 +141,11 @@ class TaskContainer
         // Here we will include the compiled Envoy file so it can register tasks into this
         // container instance. Then we will delete the PHP version of the file because
         // it is no longer needed once we have used it to register in the container.
-        include $__envoyPath;
-
-        @unlink($__envoyPath);
+        try {
+            include $__envoyPath;
+        } finally {
+            @unlink($__envoyPath);
+        }
 
         $this->replaceSubTasks();
 

--- a/src/TaskContainer.php
+++ b/src/TaskContainer.php
@@ -161,7 +161,7 @@ class TaskContainer
     protected function writeCompiledEnvoyFile($compiler, $path, $serversOnly)
     {
         file_put_contents(
-            $envoyPath = getcwd().'/Envoy'.md5_file($path).'.php',
+            $envoyPath = getcwd().'/Envoy'.md5_file($path).'-'.getmypid().'.php',
             $compiler->compile(file_get_contents($path), $serversOnly)
         );
 

--- a/tests/TaskContainerTest.php
+++ b/tests/TaskContainerTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Envoy\Tests;
 
+use Exception;
 use Laravel\Envoy\Compiler;
 use Laravel\Envoy\TaskContainer;
 use PHPUnit\Framework\TestCase;
@@ -11,25 +12,48 @@ class TaskContainerTest extends TestCase
 {
     public function test_it_writes_the_compiled_file_to_a_process_specific_path()
     {
-        $recipe = tempnam(sys_get_temp_dir(), 'Envoy');
-        file_put_contents($recipe, "@task('foo')\n    echo 'foo';\n@endtask");
+        $recipe = $this->recipe("@task('foo')\n    echo 'foo';\n@endtask");
 
         $path = $this->writeCompiledEnvoyFile($recipe);
 
-        unlink($recipe);
-        unlink($path);
-
         $this->assertStringContainsString('-'.getmypid().'.php', basename($path));
+
+        unlink($path);
+        unlink($recipe);
+    }
+
+    public function test_it_deletes_the_compiled_file_when_the_recipe_throws()
+    {
+        $recipe = $this->recipe("@setup\n    throw new Exception('boom');\n@endsetup");
+
+        try {
+            (new TaskContainer())->load($recipe, new Compiler());
+        } catch (Exception $e) {
+            ob_end_clean();
+        }
+
+        $this->assertSame([], glob(getcwd().'/Envoy'.md5_file($recipe).'*.php'));
+
+        unlink($recipe);
+    }
+
+    private function recipe($contents)
+    {
+        $recipe = tempnam(sys_get_temp_dir(), 'Envoy');
+
+        file_put_contents($recipe, $contents);
+
+        return $recipe;
     }
 
     private function writeCompiledEnvoyFile($recipe)
     {
-        $container = new TaskContainer;
+        $container = new TaskContainer();
 
         $r = new ReflectionObject($container);
         $method = $r->getMethod('writeCompiledEnvoyFile');
         $method->setAccessible(true);
 
-        return $method->invoke($container, new Compiler, $recipe, false);
+        return $method->invoke($container, new Compiler(), $recipe, false);
     }
 }

--- a/tests/TaskContainerTest.php
+++ b/tests/TaskContainerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Laravel\Envoy\Tests;
+
+use Laravel\Envoy\Compiler;
+use Laravel\Envoy\TaskContainer;
+use PHPUnit\Framework\TestCase;
+use ReflectionObject;
+
+class TaskContainerTest extends TestCase
+{
+    public function test_it_writes_the_compiled_file_to_a_process_specific_path()
+    {
+        $recipe = tempnam(sys_get_temp_dir(), 'Envoy');
+        file_put_contents($recipe, "@task('foo')\n    echo 'foo';\n@endtask");
+
+        $path = $this->writeCompiledEnvoyFile($recipe);
+
+        unlink($recipe);
+        unlink($path);
+
+        $this->assertStringContainsString('-'.getmypid().'.php', basename($path));
+    }
+
+    private function writeCompiledEnvoyFile($recipe)
+    {
+        $container = new TaskContainer;
+
+        $r = new ReflectionObject($container);
+        $method = $r->getMethod('writeCompiledEnvoyFile');
+        $method->setAccessible(true);
+
+        return $method->invoke($container, new Compiler, $recipe, false);
+    }
+}


### PR DESCRIPTION
Two Envoy processes started from the same directory with the same recipe compile to the same path, `Envoy<md5>.php` in the working directory. Each process writes it, includes it, then unlinks it, so one process can delete the file out from under another mid-include. Both invocations then die with `Task "..." is not defined.`

Adding the PID to the compiled filename gives every process its own file. I kept the file in `getcwd()` rather than moving it to `tempnam()` in the system temp dir, since the compiled recipe is included and `__DIR__` inside it would then point somewhere else. The include is now wrapped in a `try`/`finally` so a recipe that throws no longer leaves the compiled file behind, which used to self-heal on the next run when the name was shared.

Reproduced with two backgrounded `envoy run` calls in a loop, which fails within a few rounds before the change and is clean after it.

fixes #310
