### PR TITLE
Add support for guzzle 8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "guzzlehttp/guzzle": "^6.0|^7.0",
+        "guzzlehttp/guzzle": "^6.0|^7.0|^8.0",
         "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "symfony/console": "^4.3|^5.0|^6.0|^7.0|^8.0",
         "symfony/process": "^4.3|^5.0|^6.0|^7.0|^8.0"


### PR DESCRIPTION
Widen guzzlehttp/guzzle constraint to allow ^8.0 alongside existing ^6.0|^7.0, so projects on Guzzle 8 can install Envoy.